### PR TITLE
Set cap_net_raw for blackbox_exporter binary.

### DIFF
--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -2,7 +2,7 @@
 
 Name:    blackbox_exporter
 Version: 0.9.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0
 URL:     https://github.com/prometheus/blackbox_exporter
@@ -53,7 +53,7 @@ exit 0
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/blackbox_exporter
+%caps(cap_net_raw=ep) /usr/bin/blackbox_exporter
 %config(noreplace) /etc/prometheus/blackbox.yml
 /usr/lib/systemd/system/blackbox_exporter.service
 %config(noreplace) /etc/default/blackbox_exporter


### PR DESCRIPTION
the icmp prober need the capability cap_net_raw.