### PR TITLE
Changed location of configuration keys.

### DIFF
--- a/prometheus2/prometheus.default
+++ b/prometheus2/prometheus.default
@@ -1,0 +1,1 @@
+PROMETHEUS_OPTS='--storage.tsdb.path=/var/lib/prometheus/data'

--- a/prometheus2/prometheus.default
+++ b/prometheus2/prometheus.default
@@ -1,1 +1,1 @@
-PROMETHEUS_OPTS='--storage.tsdb.path=/var/lib/prometheus/data'
+PROMETHEUS_OPTS='--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/data'

--- a/prometheus2/prometheus.service
+++ b/prometheus2/prometheus.service
@@ -9,7 +9,6 @@ After=network.target
 EnvironmentFile=-/etc/default/prometheus
 User=prometheus
 ExecStart=/usr/bin/prometheus \
-          --config.file=/etc/prometheus/prometheus.yml \
           --web.console.libraries=/usr/share/prometheus/console_libraries \
           --web.console.templates=/usr/share/prometheus/consoles \
           $PROMETHEUS_OPTS

--- a/prometheus2/prometheus.service
+++ b/prometheus2/prometheus.service
@@ -10,7 +10,6 @@ EnvironmentFile=-/etc/default/prometheus
 User=prometheus
 ExecStart=/usr/bin/prometheus \
           --config.file=/etc/prometheus/prometheus.yml \
-          --storage.tsdb.path=/var/lib/prometheus/data \
           --web.console.libraries=/usr/share/prometheus/console_libraries \
           --web.console.templates=/usr/share/prometheus/consoles \
           $PROMETHEUS_OPTS

--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -2,7 +2,7 @@
 
 Name:		 prometheus2
 Version: 2.0.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Prometheus 2.0 monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io


### PR DESCRIPTION
It will be better to have these keys in `/etc/default/prometheus` for easier maintenance. In case you want to customize these options you will have to remove/modify them in `/usr/lib/systemd/system/prometheus.service`. 
If you'll put one of the in defaults, prometheus will fail to start with: `Error parsing commandline arguments: flag 'xxxxxxx' cannot be repeated`