### PR TITLE
Support Centos 6 RPM builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-_dist
+_dist*
 *.tar.gz
 .passphrase
 secret.asc
 *.jar
+*.autogen

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES = prometheus \
+PACKAGES7 = prometheus \
 prometheus2 \
 alertmanager \
 node_exporter \
@@ -16,34 +16,56 @@ redis_exporter \
 collectd_exporter \
 rabbitmq_exporter \
 pushgateway \
-sachet
+sachet \
+statsd_exporter
 
-.PHONY: $(PACKAGES)
+PACKAGES6 = node_exporter 
 
-all: $(PACKAGES)
+.PHONY: $(PACKAGES6)
+.PHONY: $(PACKAGES7)
 
-$(PACKAGES):
+all: $(PACKAGES7) $(PACKAGES6)
+
+6: $(PACKAGES6)
+
+$(PACKAGES7):
 	docker run --rm \
 		-v ${PWD}/$@:/rpmbuild/SOURCES \
-		-v ${PWD}/_dist:/rpmbuild/RPMS/x86_64 \
-		-v ${PWD}/_dist:/rpmbuild/RPMS/noarch \
+		-v ${PWD}/_dist7:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/_dist7:/rpmbuild/RPMS/noarch \
 		lest/centos7-rpm-builder \
+		build-spec SOURCES/$@.spec
+$(PACKAGES6):
+	docker run --rm \
+		-v ${PWD}/$@:/rpmbuild/SOURCES \
+		-v ${PWD}/_dist6:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/_dist6:/rpmbuild/RPMS/noarch \
+		quay.io/zoonage/centos6-rpm-build \
 		build-spec SOURCES/$@.spec
 
 sign:
 	docker run --rm \
-		-v ${PWD}/_dist:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/_dist7:/rpmbuild/RPMS/x86_64 \
 		-v ${PWD}/bin:/rpmbuild/bin \
 		-v ${PWD}/RPM-GPG-KEY-prometheus-rpm:/rpmbuild/RPM-GPG-KEY-prometheus-rpm \
 		-v ${PWD}/secret.asc:/rpmbuild/secret.asc \
 		-v ${PWD}/.passphrase:/rpmbuild/.passphrase \
 		lest/centos7-rpm-builder \
 		bin/sign
+	docker run --rm \
+		-v ${PWD}/_dist6:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/bin:/rpmbuild/bin \
+		-v ${PWD}/RPM-GPG-KEY-prometheus-rpm:/rpmbuild/RPM-GPG-KEY-prometheus-rpm \
+		-v ${PWD}/secret.asc:/rpmbuild/secret.asc \
+		-v ${PWD}/.passphrase:/rpmbuild/.passphrase \
+		quay.io/zoonage/centos6-rpm-build \
+		bin/sign
 
 publish: sign
-	package_cloud push --skip-errors prometheus-rpm/release/el/7 _dist/*.rpm
+	package_cloud push --skip-errors prometheus-rpm/release/el/7 _dist7/*.rpm
+	package_cloud push --skip-errors prometheus-rpm/release/el/6 _dist6/*.rpm
 
 clean:
-	rm -rf _dist
-	rm **/*.tar.gz
-	rm **/*.jar
+	rm -rf _dist*
+	rm -f **/*.tar.gz
+	rm -f **/*.jar

--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python3
+
+'''
+This script generates spec, unit and init files for CentOS build_filess.
+'''
+
+import jinja2
+import yaml
+import os
+import logging
+
+def renderTemplateFromFile(templates_dir, template_file, context):
+	return jinja2.Environment(
+			loader=jinja2.FileSystemLoader(templates_dir or './')
+		).get_template(template_file).render(context)
+
+def renderTemplateFromString(template_string, context):
+	return jinja2.Environment(
+		loader=jinja2.BaseLoader
+	).from_string(template_string).render(context)
+
+logging.basicConfig(level=logging.INFO)
+
+template_config = os.environ.get("TEMPLATE_CONFIG_FILE", "./templating.yaml")
+templates_dir = os.environ.get("TEMPLATES_DIRECTORY", "./templates/")
+
+with open(template_config, 'r') as tc:
+	config = yaml.load(tc)
+
+defaults = config["defaults"]
+
+for exporter_name, exporter_config in config["packages"].items():
+	logging.info("Building exporter {}".format(exporter_name))
+
+	# Build the configuration as a merge of the defaults and the exporter config
+	context = {
+		"name": exporter_name,
+		"license": exporter_config["license"],
+		"description": exporter_config["description"],
+		"summary": exporter_config["summary"],
+		"version": exporter_config["version"],
+		"URL": exporter_config["URL"],
+		"build_steps": exporter_config.get("build_steps", defaults["build_steps"]),
+
+		# These are all run through a jinja2 template with the above context
+		"tarball_unformatted": exporter_config["tarball"],
+		"sources_unformatted": exporter_config.get("sources", defaults["sources"]),
+		"sources": [],
+		"build_unformatted": exporter_config.get("build", defaults["build"]),
+		"pre_unformatted": exporter_config.get("pre", defaults["pre"]),
+		"post_unformatted": exporter_config.get("post", defaults["post"]),
+		"preun_unformatted": exporter_config.get("preun", defaults["preun"]),
+		"postun_unformatted": exporter_config.get("postun", defaults["postun"]),
+		"files_unformatted": exporter_config.get("files", defaults["files"]),
+	}
+
+	# Run the templating over these sections with the above context
+	context["tarball"] = renderTemplateFromString(context["tarball_unformatted"], context)
+	context["pre"] = renderTemplateFromString(context["pre_unformatted"], context)
+	context["post"] = renderTemplateFromString(context["post_unformatted"], context)
+	context["preun"] = renderTemplateFromString(context["preun_unformatted"], context)
+	context["postun"] = renderTemplateFromString(context["postun_unformatted"], context)
+	context["files"] = renderTemplateFromString(context["files_unformatted"], context)
+
+	context['sources'] = []
+	for source_template in context['sources_unformatted']:
+		context['sources'].append(renderTemplateFromString(source_template, context))
+
+	logging.debug("Using context {}".format(context))
+
+	for build_step in context['build_steps']:
+		template_file = "{}.tpl".format(build_step)
+		output = "{name}/{name}.{build_step}.autogen".format(**{
+			'name': context['name'],
+			'build_step': build_step,
+		})
+		logging.info("Rendering template {}/{}".format(templates_dir, template_file))
+		rendered = renderTemplateFromFile(templates_dir=templates_dir, template_file=template_file, context=context)
+		logging.info("Writing {} step {} to {}".format(exporter_name, build_step, output))
+		with open(output, 'w') as output_file:
+			output_file.write(rendered)
+
+

--- a/init.template
+++ b/init.template
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+NAME=<<< INSERT YOUR EXPORTER NAME HERE (i.e. 'node_exporter' >>>
+
+SCRIPT="/usr/bin/${NAME}"
+
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ENVFILE="/etc/default/${NAME}"
+
+start() {
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} already running with PID $(cat ${PIDFILE})" >&2
+    return 1
+  fi
+  echo "Starting ${NAME}" >&2
+  . "${ENVFILE}"
+  CMD="${SCRIPT} ${EXPORTER_ARGS}"
+  local tmp_pid="/tmp/${NAME}.pid"
+  su - "${USER}" -c "${CMD} &> ${LOGFILE} & echo \$! > ${tmp_pid}" 
+  mv "${tmp_pid}" "${PIDFILE}"
+  echo "${NAME} started with PID $(cat ${PIDFILE})" >&2
+  sleep 1
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} started successfully." >&2
+  else
+    echo "${NAME} was not started OK"
+    return 1
+  fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} not running" >&2
+    return 1
+  fi
+  echo "Stopping ${NAME}..." >&2
+  kill -15 $(cat "$PIDFILE")
+  rm -f "$PIDFILE"
+  echo "${NAME} stopped" >&2
+}
+
+status() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} is not running" >&2
+  else
+    echo "${NAME} is running" >&2
+  fi
+}
+
+uninstall() {
+  echo -n "Are you really sure you want to uninstall ${NAME}? That cannot be undone. [yes|No] "
+  local SURE
+  read SURE
+  if [ "$SURE" = "yes" ]; then
+    stop
+    rm -f "$PIDFILE"
+    echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+    update-rc.d -f <NAME> remove
+    rm -fv "$0"
+  fi
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  retart)
+    stop
+    start
+    ;;
+  status)
+  status
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|uninstall}"
+esac

--- a/mysqld_exporter/mysqld_exporter.init
+++ b/mysqld_exporter/mysqld_exporter.init
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+NAME="mysqld_exporter"
+
+SCRIPT="/usr/bin/${NAME}"
+
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ENVFILE="/etc/default/${NAME}"
+
+start() {
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} already running with PID $(cat ${PIDFILE})" >&2
+    return 1
+  fi
+  echo "Starting ${NAME}" >&2
+  . "${ENVFILE}"
+  CMD="${SCRIPT} ${EXPORTER_ARGS}"
+  local tmp_pid="/tmp/${NAME}.pid"
+  su - "${USER}" -c "${CMD} &> ${LOGFILE} & echo \$! > ${tmp_pid}" 
+  mv "${tmp_pid}" "${PIDFILE}"
+  echo "${NAME} started with PID $(cat ${PIDFILE})" >&2
+  sleep 1
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} started successfully." >&2
+  else
+    echo "${NAME} was not started OK"
+    return 1
+  fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} not running" >&2
+    return 1
+  fi
+  echo "Stopping ${NAME}..." >&2
+  kill -15 $(cat "$PIDFILE")
+  rm -f "$PIDFILE"
+  echo "${NAME} stopped" >&2
+}
+
+status() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} is not running" >&2
+  else
+    echo "${NAME} is running" >&2
+  fi
+}
+
+uninstall() {
+  echo -n "Are you really sure you want to uninstall ${NAME}? That cannot be undone. [yes|No] "
+  local SURE
+  read SURE
+  if [ "$SURE" = "yes" ]; then
+    stop
+    rm -f "$PIDFILE"
+    echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+    update-rc.d -f <NAME> remove
+    rm -fv "$0"
+  fi
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  retart)
+    stop
+    start
+    ;;
+  status)
+  status
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|uninstall}"
+esac

--- a/node_exporter/node_exporter.init
+++ b/node_exporter/node_exporter.init
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+NAME="node_exporter"
+
+SCRIPT="/usr/bin/${NAME}"
+
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ENVFILE="/etc/default/${NAME}"
+
+start() {
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} already running with PID $(cat ${PIDFILE})" >&2
+    return 1
+  fi
+  echo "Starting ${NAME}" >&2
+  . "${ENVFILE}"
+  CMD="${SCRIPT} ${EXPORTER_ARGS}"
+  local tmp_pid="/tmp/${NAME}.pid"
+  su - "${USER}" -c "${CMD} &> ${LOGFILE} & echo \$! > ${tmp_pid}" 
+  mv "${tmp_pid}" "${PIDFILE}"
+  echo "${NAME} started with PID $(cat ${PIDFILE})" >&2
+  sleep 1
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} started successfully." >&2
+  else
+    echo "${NAME} was not started OK"
+    return 1
+  fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} not running" >&2
+    return 1
+  fi
+  echo "Stopping ${NAME}..." >&2
+  kill -15 $(cat "$PIDFILE")
+  rm -f "$PIDFILE"
+  echo "${NAME} stopped" >&2
+}
+
+status() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} is not running" >&2
+  else
+    echo "${NAME} is running" >&2
+  fi
+}
+
+uninstall() {
+  echo -n "Are you really sure you want to uninstall ${NAME}? That cannot be undone. [yes|No] "
+  local SURE
+  read SURE
+  if [ "$SURE" = "yes" ]; then
+    stop
+    rm -f "$PIDFILE"
+    echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+    update-rc.d -f <NAME> remove
+    rm -fv "$0"
+  fi
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  retart)
+    stop
+    start
+    ;;
+  status)
+  status
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|uninstall}"
+esac

--- a/node_exporter/node_exporter.spec
+++ b/node_exporter/node_exporter.spec
@@ -10,6 +10,7 @@ URL:     https://github.com/prometheus/node_exporter
 Source0: https://github.com/prometheus/node_exporter/releases/download/v%{version}/node_exporter-%{version}.linux-amd64.tar.gz
 Source1: node_exporter.service
 Source2: node_exporter.default
+Source3: node_exporter.init
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -27,11 +28,18 @@ Prometheus exporter for machine metrics, written in Go with pluggable metric col
 %install
 mkdir -vp %{buildroot}/var/lib/prometheus
 mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
 mkdir -vp %{buildroot}/etc/default
 install -m 755 node_exporter %{buildroot}/usr/bin/node_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/node_exporter.service
 install -m 644 %{SOURCE2} %{buildroot}/etc/default/node_exporter
+%if 0%{?el6}
+# Centos6 assume sysv
+mkdir -vp %{buildroot}/etc/init.d/
+install -m 644 %{SOURCE3} %{buildroot}/etc/init.d/node_exporter
+%else
+# Not CentOS 6, assume systemd
+mkdir -vp %{buildroot}/usr/lib/systemd/system
+install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/node_exporter.service
+%endif
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
@@ -41,17 +49,33 @@ getent passwd prometheus >/dev/null || \
 exit 0
 
 %post
+%if 0%{?el6}
+chkconfig node_exporter on
+%else
 %systemd_post node_exporter.service
+%endif
 
 %preun
+%if 0%{?el6}
+# Nothing for centos 6
+%else
 %systemd_preun node_exporter.service
+%endif
 
 %postun
+%if 0%{?el6}
+chkconfig node_exporter off
+%else
 %systemd_postun node_exporter.service
+%endif
 
 %files
 %defattr(-,root,root,-)
 /usr/bin/node_exporter
+%if 0%{?el6}
+/etc/init.d/node_exporter
+%else
 /usr/lib/systemd/system/node_exporter.service
+%endif
 %config(noreplace) /etc/default/node_exporter
 %attr(755, prometheus, prometheus)/var/lib/prometheus

--- a/statsd_exporter/statsd_exporter.service
+++ b/statsd_exporter/statsd_exporter.service
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Prometheus StatsD exporter.
+Documentation=https://github.com/prometheus/statsd_exporter
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/statsd_exporter
+User=prometheus
+ExecStart=/usr/bin/statsd_exporter $STATSD_EXPORTER_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,0 +1,57 @@
+%define debug_package %{nil}
+
+Name:    statsd_exporter
+Version: 0.6.0
+Release: 1%{?dist}
+Summary: Prometheus StatsD exporter.
+License: ASL 2.0
+URL:     https://github.com/prometheus/statsd_exporter
+
+Source0: https://github.com/prometheus/statsd_exporter/releases/download/v%{version}/statsd_exporter-%{version}.linux-amd64.tar.gz
+Source1: statsd_exporter.service
+Source2: statsd_exporter.default
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
+
+%description
+
+Export StatsD metrics in Prometheus format.
+
+%prep
+%setup -q -n statsd_exporter-%{version}.linux-amd64
+
+%build
+/bin/true
+
+%install
+mkdir -vp %{buildroot}/var/lib/prometheus
+mkdir -vp %{buildroot}/usr/bin
+mkdir -vp %{buildroot}/usr/lib/systemd/system
+mkdir -vp %{buildroot}/etc/default
+install -m 755 statsd_exporter %{buildroot}/usr/bin/statsd_exporter
+install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/statsd_exporter.service
+install -m 644 %{SOURCE2} %{buildroot}/etc/default/statsd_exporter
+
+%pre
+getent group prometheus >/dev/null || groupadd -r prometheus
+getent passwd prometheus >/dev/null || \
+  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+          -c "Prometheus services" prometheus
+exit 0
+
+%post
+%systemd_post statsd_exporter.service
+
+%preun
+%systemd_preun statsd_exporter.service
+
+%postun
+%systemd_postun statsd_exporter.service
+
+%files
+%defattr(-,root,root,-)
+/usr/bin/statsd_exporter
+/usr/lib/systemd/system/statsd_exporter.service
+%config(noreplace) /etc/default/statsd_exporter
+%attr(755, prometheus, prometheus)/var/lib/prometheus

--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+NAME={{name}}
+
+SCRIPT="/usr/bin/${NAME}"
+
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ENVFILE="/etc/default/${NAME}"
+
+start() {
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} already running with PID $(cat ${PIDFILE})" >&2
+    return 1
+  fi
+  echo "Starting ${NAME}" >&2
+  . "${ENVFILE}"
+  CMD="${SCRIPT} ${EXPORTER_ARGS}"
+  local tmp_pid="/tmp/${NAME}.pid"
+  su - "${USER}" -c "${CMD} &> ${LOGFILE} & echo \$! > ${tmp_pid}" 
+  mv "${tmp_pid}" "${PIDFILE}"
+  echo "${NAME} started with PID $(cat ${PIDFILE})" >&2
+  sleep 1
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} started successfully." >&2
+  else
+    echo "${NAME} was not started OK"
+    return 1
+  fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} not running" >&2
+    return 1
+  fi
+  echo "Stopping ${NAME}..." >&2
+  kill -15 $(cat "$PIDFILE")
+  rm -f "$PIDFILE"
+  echo "${NAME} stopped" >&2
+}
+
+status() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} is not running" >&2
+  else
+    echo "${NAME} is running" >&2
+  fi
+}
+
+uninstall() {
+  echo -n "Are you really sure you want to uninstall ${NAME}? That cannot be undone. [yes|No] "
+  local SURE
+  read SURE
+  if [ "$SURE" = "yes" ]; then
+    stop
+    rm -f "$PIDFILE"
+    echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+    update-rc.d -f <NAME> remove
+    rm -fv "$0"
+  fi
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  retart)
+    stop
+    start
+    ;;
+  status)
+  status
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|uninstall}"
+esac

--- a/templates/spec.tpl
+++ b/templates/spec.tpl
@@ -1,0 +1,51 @@
+%define debug_package %{nil}
+
+Name:    {{name}}
+Version: {{version}}
+Release: 1%{?dist}
+Summary: {{summary}}
+License: {{license}}
+URL:     {{URL}}
+
+{%- for source in sources %}
+Source{{loop.index - 1}}: {{source}}
+{%- endfor %}
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
+
+%description
+
+{{description}}
+
+%prep
+%setup -q -n {{name}}-%{version}.linux-amd64
+
+%build
+# Custom build from templating
+{{build}}
+
+%install
+# Custom install from templating
+{{install}}
+
+%pre
+# Custom pre from templating
+{{pre}}
+
+%post
+# Custom post from templating
+{{post}}
+
+%preun
+# Custom preun from templating
+{{preun}}
+
+%postun
+
+# Custom postun from templating
+{{postun}}
+
+%files
+# Custom files from templating
+{{files}}

--- a/templates/unit.tpl
+++ b/templates/unit.tpl
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description={{summary}}
+Documentation={{URL}}
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/{{name}}
+User=prometheus
+ExecStart=/usr/bin/{{name}} ${{name|upper}}_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/templating.yaml
+++ b/templating.yaml
@@ -1,0 +1,75 @@
+# Configure some defaults that will probably be common
+# to each package
+defaults:
+  tarball: '{{UR:}}/releases/download/v{{version}}-rc.3/{{name}}-{{version}}-rc.3.linux-amd64.tar.gz'
+  build_steps:
+    - spec
+    - unit
+    - init
+  build: |
+    /bin/true
+  pre: |
+    getent group prometheus >/dev/null || groupadd -r prometheus
+    getent passwd prometheus >/dev/null || \
+      useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+              -c "Prometheus services" prometheus
+    exit 0
+  post: |
+    %if 0%{?el6}
+    chkconfig {{name}} on
+    %else
+    %systemd_post {{name}}.service
+    %endif
+  preun: |
+    %if 0%{?el6}
+    # Nothing for centos 6
+    %else
+    %systemd_preun {{name}}.service
+    %endif
+  postun: |
+    %if 0%{?el6}
+    chkconfig {{name}} off
+    %else
+    %systemd_postun {{name}}.service
+    %endif
+  install: |
+    mkdir -vp %{buildroot}/var/lib/prometheus
+    mkdir -vp %{buildroot}/usr/bin
+    mkdir -vp %{buildroot}/etc/default
+    install -m 755 {{name}} %{buildroot}/usr/bin/{{name}}
+    install -m 644 %{SOURCE2} %{buildroot}/etc/default/{{name}}
+    %if 0%{?el6}
+    # Centos6 assume sysv
+    mkdir -vp %{buildroot}/etc/init.d/
+    install -m 644 %{SOURCE3} %{buildroot}/etc/init.d/{{name}}
+    %else
+    # Not CentOS 6, assume systemd
+    mkdir -vp %{buildroot}/usr/lib/systemd/system
+    install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/{{name}}.service
+    %endif
+  files: |
+    %defattr(-,root,root,-)
+    /usr/bin/{{name}}
+    %if 0%{?el7}
+    /usr/lib/systemd/system/{{name}}.service
+    %else
+    /etc/init.d/{{name}}
+    %endif
+    %config(noreplace) /etc/default/{{name}}
+    %attr(755, prometheus, prometheus)/var/lib/prometheus
+  sources:
+    - '{{tarball}}'
+    - '{{name}}.service'
+    - '{{name}}.default'
+    - '{{name}}.init'
+
+# Per-package configuration
+packages:
+  node_exporter:
+    version: 0.15.2
+    license: ASL 2.0
+    URL: https://github.com/prometheus/node_exporter
+    summary: Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
+    tarball: https://github.com/prometheus/node_exporter/releases/download/v0.16.0-rc.3/node_exporter-0.16.0-rc.3.darwin-386.tar.gz
+    description: Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
+      


### PR DESCRIPTION
# Description

This commit adds in support for building these exporters for centos 6, however it only actually builds node_exporter at the moment.

I forked your centos7 RPM builder and created https://github.com/zoonage/centos-rpm-builder-docker, which allows for building centos 6 as well. I've then used this centos6 builder container to build the centos 6 files.

# Changes
- Move `_dist` to the release specific release directory i.e. `_dist7` and `_dist6`
- Update Makefile to support these new dist directories
- Modify `node_exporter` to be able to support Centos 6
- Modify `mysqld_exporter` to be able to support Centos 7