### PR TITLE
Use RPM macros and install -D

### DIFF
--- a/alertmanager/alertmanager.spec
+++ b/alertmanager/alertmanager.spec
@@ -1,15 +1,18 @@
 %define debug_package %{nil}
 
-Name:		 alertmanager
+Name:    alertmanager
 Version: 0.14.0
 Release: 1%{?dist}
 Summary: Prometheus Alertmanager.
 License: ASL 2.0
-URL:     https://github.com/prometheus/alertmanager
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/alertmanager/releases/download/v%{version}/alertmanager-%{version}.linux-amd64.tar.gz
-Source1: alertmanager.service
-Source2: alertmanager.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
 
 %description
 
@@ -19,44 +22,40 @@ the correct receiver integration such as email, PagerDuty, or OpsGenie. It also
 takes care of silencing and inhibition of alerts.
 
 %prep
-%setup -q -n alertmanager-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/etc/prometheus
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 alertmanager %{buildroot}/usr/bin/alertmanager
-install -m 755 amtool %{buildroot}/usr/bin/amtool
-install -m 644 simple.yml %{buildroot}/etc/prometheus/alertmanager.yml
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/alertmanager.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/alertmanager
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 644 simple.yml %{buildroot}%{_sysconfdir}/prometheus/%{name}.yml
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 755 amtool %{buildroot}%{_bindir}/amtool
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post alertmanager.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun alertmanager.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun alertmanager.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/alertmanager
-/usr/bin/amtool
-%config(noreplace) /etc/prometheus/alertmanager.yml
-/usr/lib/systemd/system/alertmanager.service
-%config(noreplace) /etc/default/alertmanager
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%config(noreplace) %{_sysconfdir}/prometheus/%{name}.yml
+%{_bindir}/%{name}
+%{_bindir}/amtool
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/apache_exporter/apache_exporter.spec
+++ b/apache_exporter/apache_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.5.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for apache mod_status statistics
 License: MIT
-URL:     https://github.com/Lusitaniae/apache_exporter
+URL:     https://github.com/Lusitaniae/%{name}
 
-Source0: https://github.com/Lusitaniae/apache_exporter/releases/download/v%{version}/apache_exporter-%{version}.linux-amd64.tar.gz
-Source1: apache_exporter.service
-Source2: apache_exporter.default
+Source0: https://github.com/Lusitaniae/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Prometheus exporter for apache mod_status statistics
 
 %prep
-%setup -q -n apache_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 apache_exporter %{buildroot}/usr/bin/apache_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/apache_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/apache_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post apache_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun apache_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun apache_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/apache_exporter
-/usr/lib/systemd/system/apache_exporter.service
-%config(noreplace) /etc/default/apache_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.12.0
 Release: 1%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0
-URL:     https://github.com/prometheus/blackbox_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/blackbox_exporter/releases/download/v%{version}/blackbox_exporter-%{version}.linux-amd64.tar.gz
-Source1: blackbox_exporter.service
-Source2: blackbox_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,42 +19,38 @@ Requires(pre): shadow-utils
 The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP.
 
 %prep
-%setup -q -n blackbox_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/etc/prometheus
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 blackbox_exporter %{buildroot}/usr/bin/blackbox_exporter
-install -m 644 blackbox.yml %{buildroot}/etc/prometheus/blackbox.yml
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/blackbox_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/blackbox_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 blackbox.yml %{buildroot}%{_sysconfdir}/prometheus/blackbox.yml
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post blackbox_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun blackbox_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun blackbox_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-%caps(cap_net_raw=ep) /usr/bin/blackbox_exporter
-%config(noreplace) /etc/prometheus/blackbox.yml
-/usr/lib/systemd/system/blackbox_exporter.service
-%config(noreplace) /etc/default/blackbox_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%caps(cap_net_raw=ep) %{_bindir}/%{name}
+%config(noreplace) %{_sysconfdir}/prometheus/blackbox.yml
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/collectd_exporter/collectd_exporter.spec
+++ b/collectd_exporter/collectd_exporter.spec
@@ -5,13 +5,11 @@ Version: 0.4.0
 Release: 1%{?dist}
 Summary: Collectd stats exporter for Prometheus
 License: ASL 2.0
-URL:     https://github.com/prometheus/collectd_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/collectd_exporter/releases/download/v%{version}/collectd_exporter-%{version}.linux-amd64.tar.gz
-Source1: collectd_exporter.service
-Source2: collectd_exporter.default
-
-
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -24,39 +22,36 @@ HTTP POST as sent by collectd's write_http plugin, and transforms and exposes
 them for consumption by Prometheus.
 
 %prep
-%setup -q -n collectd_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 collectd_exporter %{buildroot}/usr/bin/collectd_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/collectd_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/collectd_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post collectd_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun collectd_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun collectd_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/collectd_exporter
-/usr/lib/systemd/system/collectd_exporter.service
-%config(noreplace) /etc/default/collectd_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/consul_exporter/consul_exporter.spec
+++ b/consul_exporter/consul_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.3.0
 Release: 1%{?dist}
 Summary: Prometheus Consul exporter.
 License: ASL 2.0
-URL:     https://github.com/prometheus/consul_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/consul_exporter/releases/download/v%{version}/consul_exporter-%{version}.linux-amd64.tar.gz
-Source1: consul_exporter.service
-Source2: consul_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Export Consul service health to Prometheus.
 
 %prep
-%setup -q -n consul_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 consul_exporter %{buildroot}/usr/bin/consul_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/consul_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/consul_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post consul_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun consul_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun consul_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/consul_exporter
-/usr/lib/systemd/system/consul_exporter.service
-%config(noreplace) /etc/default/consul_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/elasticsearch_exporter/elasticsearch_exporter.spec
+++ b/elasticsearch_exporter/elasticsearch_exporter.spec
@@ -5,11 +5,11 @@ Version: 1.0.2
 Release: 1%{?dist}
 Summary: Elasticsearch stats exporter for Prometheus
 License: ASL 2.0
-URL:     https://github.com/justwatchcom/elasticsearch_exporter
+URL:     https://github.com/justwatchcom/%{name}
 
-Source0: https://github.com/justwatchcom/elasticsearch_exporter/releases/download/v%{version}/elasticsearch_exporter-%{version}.linux-amd64.tar.gz
-Source1: elasticsearch_exporter.service
-Source2: elasticsearch_exporter.default
+Source0: https://github.com/justwatchcom/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Elasticsearch stats exporter for Prometheus.
 
 %prep
-%setup -q -n elasticsearch_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 elasticsearch_exporter %{buildroot}/usr/bin/elasticsearch_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/elasticsearch_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/elasticsearch_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post elasticsearch_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun elasticsearch_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun elasticsearch_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/elasticsearch_exporter
-/usr/lib/systemd/system/elasticsearch_exporter.service
-%config(noreplace) /etc/default/elasticsearch_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/graphite_exporter/graphite_exporter.spec
+++ b/graphite_exporter/graphite_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.2.0
 Release: 1%{?dist}
 Summary: Prometheus Graphite exporter.
 License: ASL 2.0
-URL:     https://github.com/prometheus/graphite_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/graphite_exporter/releases/download/v%{version}/graphite_exporter-%{version}.linux-amd64.tar.gz
-Source1: graphite_exporter.service
-Source2: graphite_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 An exporter for metrics exported in the Graphite plaintext protocol. It accepts data over both TCP and UDP, and transforms and exposes them for consumption by Prometheus.
 
 %prep
-%setup -q -n graphite_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 graphite_exporter %{buildroot}/usr/bin/graphite_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/graphite_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/graphite_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post graphite_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun graphite_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun graphite_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/graphite_exporter
-/usr/lib/systemd/system/graphite_exporter.service
-%config(noreplace) /etc/default/graphite_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/haproxy_exporter/haproxy_exporter.spec
+++ b/haproxy_exporter/haproxy_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.8.0
 Release: 1%{?dist}
 Summary: Haproxy exporter
 License: ASL 2.0
-URL:     https://github.com/prometheus/haproxy_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/haproxy_exporter/releases/download/v%{version}/haproxy_exporter-%{version}.linux-amd64.tar.gz
-Source1: haproxy_exporter.service
-Source2: haproxy_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption
 
 %prep
-%setup -q -n haproxy_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 haproxy_exporter %{buildroot}/usr/bin/haproxy_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/haproxy_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/haproxy_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post haproxy_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun haproxy_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun haproxy_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/haproxy_exporter
-/usr/lib/systemd/system/haproxy_exporter.service
-%config(noreplace) /etc/default/haproxy_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/jmx_exporter/jmx_exporter.spec
+++ b/jmx_exporter/jmx_exporter.spec
@@ -6,11 +6,11 @@ Release: 1%{?dist}
 BuildArch: noarch
 Summary: Prometheus exporter for mBeans scrape and expose.
 License: ASL 2.0
-URL:     https://github.com/prometheus/jmx_exporter
+URL:     https://github.com/prometheus/%{name}
 
 Source0: http://search.maven.org/remotecontent?filepath=io/prometheus/jmx/jmx_prometheus_httpserver/%{version}/jmx_prometheus_httpserver-%{version}-jar-with-dependencies.jar 
-Source1: jmx_exporter.service
-Source2: jmx_exporter.default
+Source1: %{name}.service
+Source2: %{name}.default
 
 Requires: java
 
@@ -24,33 +24,30 @@ A Collector that can configurably scrape and expose mBeans of a JMX target. It m
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/share/prometheus/jmx_exporter
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 644 %{SOURCE0} %{buildroot}/usr/share/prometheus/jmx_exporter/jmx_exporter.jar
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/jmx_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/jmx_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 644 %{SOURCE0} %{buildroot}%{_datarootdir}/prometheus/%{name}/%{name}.jar
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post jmx_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun jmx_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun jmx_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/share/prometheus/jmx_exporter/jmx_exporter.jar
-/usr/lib/systemd/system/jmx_exporter.service
-%config(noreplace) /etc/default/jmx_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_datarootdir}/prometheus/%{name}/%{name}.jar
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/mysqld_exporter/mysqld_exporter.spec
+++ b/mysqld_exporter/mysqld_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.10.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for MySQL server metrics.
 License: ASL 2.0
-URL:     https://github.com/prometheus/mysqld_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/mysqld_exporter/releases/download/v%{version}/mysqld_exporter-%{version}.linux-amd64.tar.gz
-Source1: mysqld_exporter.service
-Source2: mysqld_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Prometheus exporter for MySQL server metrics.
 
 %prep
-%setup -q -n mysqld_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 mysqld_exporter %{buildroot}/usr/bin/mysqld_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/mysqld_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/mysqld_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post mysqld_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun mysqld_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun mysqld_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/mysqld_exporter
-/usr/lib/systemd/system/mysqld_exporter.service
-%config(noreplace) /etc/default/mysqld_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/node_exporter/node_exporter.spec
+++ b/node_exporter/node_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.15.2
 Release: 1%{?dist}
 Summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
 License: ASL 2.0
-URL:     https://github.com/prometheus/node_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/node_exporter/releases/download/v%{version}/node_exporter-%{version}.linux-amd64.tar.gz
-Source1: node_exporter.service
-Source2: node_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
 
 %prep
-%setup -q -n node_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 node_exporter %{buildroot}/usr/bin/node_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/node_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/node_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post node_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun node_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun node_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/node_exporter
-/usr/lib/systemd/system/node_exporter.service
-%config(noreplace) /etc/default/node_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -5,11 +5,11 @@ Version: 0.4.0
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0
-URL:     https://github.com/prometheus/pushgateway
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/pushgateway/releases/download/v%{version}/pushgateway-%{version}.linux-amd64.tar.gz
-Source1: pushgateway.service
-Source2: pushgateway.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %description
 
@@ -18,37 +18,36 @@ Since these kinds of jobs may not exist long enough to be scraped, they can inst
 a Pushgateway. The Pushgateway then exposes these metrics to Prometheus.
 
 %prep
-%setup -q -n pushgateway-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 pushgateway %{buildroot}/usr/bin/pushgateway
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/pushgateway.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/pushgateway
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post pushgateway.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun pushgateway.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun pushgateway.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/pushgateway
-/usr/lib/systemd/system/pushgateway.service
-%config(noreplace) /etc/default/pushgateway
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/rabbitmq_exporter/rabbitmq_exporter.spec
+++ b/rabbitmq_exporter/rabbitmq_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.26.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for RabbitMQ metrics
 License: MIT
-URL:     https://github.com/kbudde/rabbitmq_exporter
+URL:     https://github.com/kbudde/%{name}
 
-Source0: https://github.com/kbudde/rabbitmq_exporter/releases/download/v%{version}/rabbitmq_exporter-%{version}.linux-amd64.tar.gz
-Source1: rabbitmq_exporter.service
-Source2: rabbitmq_exporter.default
+Source0: https://github.com/kbudde/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Prometheus exporter for RabbitMQ metrics.
 
 %prep
-%setup -q -n rabbitmq_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 rabbitmq_exporter %{buildroot}/usr/bin/rabbitmq_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/rabbitmq_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/rabbitmq_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
-getent group prometheus >/dev/null || groupadd --system prometheus
+getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd --system --gid=prometheus --home=/var/lib/prometheus --shell=/sbin/nologin \
-          --comment="Prometheus services" prometheus
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
+          -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post rabbitmq_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun rabbitmq_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun rabbitmq_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/rabbitmq_exporter
-/usr/lib/systemd/system/rabbitmq_exporter.service
-%config(noreplace) /etc/default/rabbitmq_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/redis_exporter/redis_exporter.spec
+++ b/redis_exporter/redis_exporter.spec
@@ -5,11 +5,11 @@ Version: v0.14
 Release: 1%{?dist}
 Summary: Redis stats exporter for Prometheus
 License: MIT
-URL:     https://github.com/oliver006/redis_exporter
+URL:     https://github.com/oliver006/%{name}
 
-Source0: https://github.com/oliver006/redis_exporter/releases/download/%{version}/redis_exporter-%{version}.linux-amd64.tar.gz
-Source1: redis_exporter.service
-Source2: redis_exporter.default
+Source0: https://github.com/oliver006/%{name}/releases/download/%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Redis stats exporter for Prometheus.
 
 %prep
-%setup -q -c -n redis_exporter-%{version}.linux-amd64
+%setup -q -c -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 redis_exporter %{buildroot}/usr/bin/redis_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/redis_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/redis_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post redis_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun redis_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun redis_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/redis_exporter
-/usr/lib/systemd/system/redis_exporter.service
-%config(noreplace) /etc/default/redis_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/sachet/sachet.spec
+++ b/sachet/sachet.spec
@@ -1,57 +1,51 @@
-Name:       sachet  
+Name:       sachet
 Version:    0.0.5
 Release:    1%{?dist}
 Summary:    SMS alerts for Prometheus Alertmanager
-License:    BSD 
-URL:        https://github.com/messagebird/sachet
-Source0:    https://github.com/messagebird/sachet/releases/download/%{version}/sachet-%{version}.linux-amd64.tar.gz
-Source1:    sachet.service
-Source2:    sachet.default
-Source3:    sachet.yml
+License:    BSD
+URL:        https://github.com/messagebird/%{name}
+Source0:    https://github.com/messagebird/%{name}/releases/download/%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1:    %{name}.service
+Source2:    %{name}.default
+Source3:    %{name}.yml
 
-BuildRequires:  golang  
-Requires:   make    
+Requires:   make
 
 %description
 Sachet (or सचेत) is Hindi for conscious. Sachet is an SMS alerting tool for the Prometheus Alertmanager.
 
 %prep
-%setup -q -n sachet-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -p %{buildroot}%{_bindir}/
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/etc/prometheus
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 sachet %{buildroot}%{_bindir}/
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/sachet.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/sachet
-install -m 640 %{SOURCE3} %{buildroot}/etc/prometheus/sachet.yml
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
+install -D -m 640 %{SOURCE3} %{buildroot}%{_sysconfdir}/prometheus/%{name}.yml
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post sachet.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun sachet.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun sachet.service
+%systemd_postun %{name}.service
 
 %files
-%{_bindir}/sachet
-%doc
-/usr/lib/systemd/system/sachet.service
-%config(noreplace) /etc/default/sachet
-%config(noreplace) /etc/prometheus/sachet.yml
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%config(noreplace) %{_sysconfdir}/prometheus/%{name}.yml
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.9.0
 Release: 2%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0
-URL:     https://github.com/prometheus/snmp_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/snmp_exporter/releases/download/v%{version}/snmp_exporter-%{version}.linux-amd64.tar.gz
-Source1: snmp_exporter.service
-Source2: snmp_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,42 +19,38 @@ Requires(pre): shadow-utils
 This is an exporter that exposes information gathered from SNMP for use by the Prometheus monitoring system.
 
 %prep
-%setup -q -n snmp_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/etc/prometheus
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 snmp_exporter %{buildroot}/usr/bin/snmp_exporter
-install -m 644 snmp.yml %{buildroot}/etc/prometheus/snmp.yml
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/snmp_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/snmp_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 644 snmp.yml %{buildroot}%{_sysconfdir}/prometheus/snmp.yml
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post snmp_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun snmp_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun snmp_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/snmp_exporter
-%config(noreplace) /etc/prometheus/snmp.yml
-/usr/lib/systemd/system/snmp_exporter.service
-%config(noreplace) /etc/default/snmp_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%config(noreplace) %{_sysconfdir}/prometheus/snmp.yml
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus

--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -5,11 +5,11 @@ Version: 0.6.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0
-URL:     https://github.com/prometheus/statsd_exporter
+URL:     https://github.com/prometheus/%{name}
 
-Source0: https://github.com/prometheus/statsd_exporter/releases/download/v%{version}/statsd_exporter-%{version}.linux-amd64.tar.gz
-Source1: statsd_exporter.service
-Source2: statsd_exporter.default
+Source0: https://github.com/prometheus/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
 
 %{?systemd_requires}
 Requires(pre): shadow-utils
@@ -19,39 +19,36 @@ Requires(pre): shadow-utils
 Export StatsD metrics in Prometheus format.
 
 %prep
-%setup -q -n statsd_exporter-%{version}.linux-amd64
+%setup -q -n %{name}-%{version}.linux-amd64
 
 %build
 /bin/true
 
 %install
-mkdir -vp %{buildroot}/var/lib/prometheus
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/lib/systemd/system
-mkdir -vp %{buildroot}/etc/default
-install -m 755 statsd_exporter %{buildroot}/usr/bin/statsd_exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/statsd_exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/etc/default/statsd_exporter
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
-  useradd -r -g prometheus -d /var/lib/prometheus -s /sbin/nologin \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
 exit 0
 
 %post
-%systemd_post statsd_exporter.service
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun statsd_exporter.service
+%systemd_preun %{name}.service
 
 %postun
-%systemd_postun statsd_exporter.service
+%systemd_postun %{name}.service
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/statsd_exporter
-/usr/lib/systemd/system/statsd_exporter.service
-%config(noreplace) /etc/default/statsd_exporter
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus


### PR DESCRIPTION
This uses RPM macros (https://fedoraproject.org/wiki/Packaging:RPMMacros) for common locations. It also uses install -D which removes the need for mkdir -p.