### PR TITLE
Bump node_exporter from 0.15.2 to 0.16.0

### DIFF
--- a/node_exporter/node_exporter.spec
+++ b/node_exporter/node_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    node_exporter
-Version: 0.15.2
+Version: 0.16.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
 License: ASL 2.0


### PR DESCRIPTION
See [the changelog] for more information.

[the changelog]: https://github.com/prometheus/node_exporter/blob/v0.16.0/CHANGELOG.md#0160--2018-05-15