### PR TITLE
Bump rabbitmq_exporter from 0.26.0 to 0.28.0

### DIFF
--- a/rabbitmq_exporter/rabbitmq_exporter.spec
+++ b/rabbitmq_exporter/rabbitmq_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    rabbitmq_exporter
-Version: 0.26.0
+Version: 0.28.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for RabbitMQ metrics
 License: MIT


### PR DESCRIPTION
Descriptions of the changes in each release:
- https://github.com/kbudde/rabbitmq_exporter/releases/tag/v0.27.0
- https://github.com/kbudde/rabbitmq_exporter/releases/tag/v0.27.1
- https://github.com/kbudde/rabbitmq_exporter/releases/tag/v0.28.0