### PR TITLE
Update init.tpl

### DIFF
--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# chkconfig: 2345 60 20
+# description: ${NAME}
+
 {% block variables %}
 NAME={{name}}
 SCRIPT="/usr/bin/${NAME}"

--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # chkconfig: 2345 60 20
-# description: ${NAME}
+# description: {{name}}
 
 {% block variables %}
 NAME={{name}}


### PR DESCRIPTION
Without `chkconfig` and `descriptions` in the init file - then `chkconfig --add` won't work on RedHat 6.x - barfs with error:

`service node_exporter does not support chkconfig`

I've set expected run levels (2345) which I think are ok - but start and stop are wild guesses based on SSHD.