### PR TITLE
sachet version 0.0.8

### DIFF
--- a/sachet/sachet.spec
+++ b/sachet/sachet.spec
@@ -1,5 +1,5 @@
 Name:       sachet
-Version:    0.0.5
+Version:    0.0.8
 Release:    1%{?dist}
 Summary:    SMS alerts for Prometheus Alertmanager
 License:    BSD


### PR DESCRIPTION
I assume that changing the version number in sachet.spec is what it takes to use a newer version?
That's how it was done here:
https://github.com/lest/prometheus-rpm/pull/56/commits/fbb06bbf6a1a6486d1713c0d65cd250261a300da