### PR TITLE
Bump postgres exporter version to 0.4.7

### DIFF
--- a/postgres_exporter/postgres_exporter.spec
+++ b/postgres_exporter/postgres_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    postgres_exporter
-Version: 0.4.1
+Version: 0.4.7
 Release: 1%{?dist}
 Summary: Prometheus exporter for PostgreSQL server metrics
 License: ASL 2.0

--- a/templating.yaml
+++ b/templating.yaml
@@ -54,7 +54,7 @@ packages:
     context:
       static: 
         <<: *default_static_context
-        version: 0.4.6
+        version: 0.4.7
         license: ASL 2.0
         summary: Prometheus exporter for PostgreSQL server metrics.
         description: |


### PR DESCRIPTION
Bump postgres exporter version to 0.4.7 to support postgres 11 (support 'B' suffix in units)