### PR TITLE
Fix to initd restart

### DIFF
--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -82,7 +82,7 @@ case "$1" in
   uninstall)
     uninstall
     ;;
-  retart)
+  restart)
     stop
     start
     ;;


### PR DESCRIPTION
Fix to typo in generated initd entry:  "retart" => "restart". Found on Centos6 node_exporter build.