### PR TITLE
Update prometheus2.spec to 2.6.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,9 +1,9 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.5.0
+Version: 2.6.0
 Release: 1%{?dist}
-Summary: The Prometheus 2.5.0 monitoring system and time series database.
+Summary: The Prometheus 2.6.0 monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io
 Conflicts: prometheus


### PR DESCRIPTION
Bumping Prometheus version to 2.6.0, released on 2018-12-17