### PR TITLE
Allow node_exporter (and others) to be run as non root

### DIFF
--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -29,7 +29,7 @@ start() {
     USER=root
   fi
 
-  daemon --user $USER --pidfile="$PIDFILE" "${SCRIPT} &"  2&> $LOGFILE
+  daemon --user $USER --pidfile="$PIDFILE" "${SCRIPT} ${EXPORTER_ARGS} &"  2&> $LOGFILE
 
   echo `pidof $NAME` > ${PIDFILE}
 

--- a/templates/init.tpl
+++ b/templates/init.tpl
@@ -9,6 +9,7 @@
 
 {% block variables %}
 NAME={{name}}
+DFLTRUNAS=prometheus
 SCRIPT="/usr/bin/${NAME}"
 PIDFILE="/var/run/${NAME}.pid"
 LOGFILE="/var/log/${NAME}.log"
@@ -25,11 +26,11 @@ start() {
   echo "Starting ${NAME}" >&2
   . "${ENVFILE}"
 
-  if [ -z $USER ]; then
-    USER=root
+  if [ -z $RUNAS ]; then
+    RUNAS=${DFLTRUNAS}
   fi
 
-  daemon --user $USER --pidfile="$PIDFILE" "${SCRIPT} ${EXPORTER_ARGS} &"  2&> $LOGFILE
+  daemon --user $RUNAS --pidfile="$PIDFILE" "${SCRIPT} ${EXPORTER_ARGS} &"  2&> $LOGFILE
 
   echo `pidof $NAME` > ${PIDFILE}
 
@@ -100,5 +101,5 @@ case "$1" in
   status
   ;;
   *)
-    echo "Usage: $0 {start|stop|restart|uninstall}"
+    echo "Usage: $0 {start|stop|restart|status|uninstall}"
 esac


### PR DESCRIPTION

 * Support running as prometheus user (via USER=  added to /etc/defaults by end user)

 * Fix "service node_exporter restart" bug on el6  - $USER  needs to be set

 * Keep everything running as root by default 