### PR TITLE
Add alertmanager 0.16.0

### DIFF
--- a/alertmanager/alertmanager.spec
+++ b/alertmanager/alertmanager.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    alertmanager
-Version: 0.15.3
+Version: 0.16.0
 Release: 1%{?dist}
 Summary: Prometheus Alertmanager.
 License: ASL 2.0


### PR DESCRIPTION
builds ok on el7:
$make alertmanager
...
Wrote: /rpmbuild/RPMS/x86_64/alertmanager-0.16.0-1.el7.centos.x86_64.rpm
...