### PR TITLE
Prometheus version bump - 2.7.1

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,9 +1,9 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.7.0
+Version: 2.7.1
 Release: 1%{?dist}
-Summary: The Prometheus 2.7.0 monitoring system and time series database.
+Summary: The Prometheus 2.7.1 monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io
 Conflicts: prometheus


### PR DESCRIPTION
Bugfix and security release:

https://github.com/prometheus/prometheus/releases/tag/v2.7.1