### PR TITLE
Update snmp_exporter.spec

### DIFF
--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    snmp_exporter
-Version: 0.14.0
+Version: 0.15.0
 Release: 1%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0


### PR DESCRIPTION
Version bump to 0.15.0:

---
This release includes changes to both the generator.yml format and the default output of the generator for lookups.

[CHANGE/FEATURE] Support multi-index lookups. This changes old_index to be a list old_indexes in generator.yml. (#339)
[CHANGE/FEATURE] Allow keeping of old labels from lookups, enabled by default (#339)
[CHANGE] The previous example modules if_mib_ifalias, if_mib_ifdescr, and if_mib_ifname have been removed from snmp.yml/generator.yml. These labels are now all available on the default if_mib example module (#339)
[FEATURE] Add EnumAsInfo and EnumAsStateSet type overrides (#378)
[ENHANCEMENT] Better error messages when an index can't be handled (#369)
