### PR TITLE
new release -2 of node_exporter to pull in initd fixes

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -28,7 +28,9 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
+        # Remove release line below to Revert release to 1 when version changes 
         version: 0.17.0
+        release: 2
         license: ASL 2.0
         URL: https://github.com/prometheus/node_exporter
         summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.


### PR DESCRIPTION
Request to rebuild node_exporter rpms to pull in initd fixes since last bump in version (Nov2018).