### PR TITLE
Bumping Prometheus to 2.9.2

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,9 +1,9 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.9.1
+Version: 2.9.2
 Release: 1%{?dist}
-Summary: The Prometheus 2.9.1 monitoring system and time series database.
+Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io
 Conflicts: prometheus


### PR DESCRIPTION
Prometheus 2.9.2 released:

    [BUGFIX] Make sure subquery range is taken into account for selection #5467
    [BUGFIX] Exhaust every request body before closing it #5166
    [BUGFIX] Cmd/promtool: return errors from rule evaluations #5483
    [BUGFIX] Remote Storage: string interner should not panic in release #5487
    [BUGFIX] Fix memory allocation regression in mergedPostings.Seek tsdb#586

I'm also proposing changing the summary to just 'Prometheus 2.x', so we don't have to keep updating it