### PR TITLE
Update Pushgateway to 0.8.0

### DIFF
--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 pushgateway
-Version: 0.7.0
+Version: 0.8.0
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0


### PR DESCRIPTION
[CHANGE] Run as user nobody in Docker. #242
[CHANGE] Adjust --web.route-prefix to work the same as in Prometheus. #190
[FEATURE] Add --web.external-url flag (like in Prometheus). #190