### PR TITLE
Initial version of Thanos RPM package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PACKAGES7 = prometheus \
 prometheus2 \
 alertmanager \
+thanos \
 elasticsearch_exporter \
 blackbox_exporter \
 consul_exporter \
@@ -13,7 +14,7 @@ rabbitmq_exporter \
 pushgateway \
 sachet \
 statsd_exporter \
-ping_exporter 
+ping_exporter
 
 .PHONY: $(PACKAGES7)
 

--- a/thanos/thanos-compact.default
+++ b/thanos/thanos-compact.default
@@ -1,0 +1,1 @@
+THANOS_COMPACT_OPTS='--http-address 0.0.0.0:19191'

--- a/thanos/thanos-compact.service
+++ b/thanos/thanos-compact.service
@@ -1,0 +1,18 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Thanos Compactor service.
+Documentation=https://github.com/improbable-eng/thanos/
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/thanos-compact
+User=prometheus
+ExecStart=/usr/bin/thanos compact \
+          --tsdb.path=/var/lib/thanos/compact \
+          $THANOS_COMPACT_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/thanos/thanos-query.default
+++ b/thanos/thanos-query.default
@@ -1,0 +1,1 @@
+THANOS_QUERY_OPTS='--cluster.disable --http-address 0.0.0.0:19192 --grpc-address 0.0.0.0:19092 --store 127.0.0.1:10901'

--- a/thanos/thanos-query.service
+++ b/thanos/thanos-query.service
@@ -1,0 +1,18 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Thanos Query service.
+Documentation=https://github.com/improbable-eng/thanos/
+After=network.target
+After=thanos-store.service
+
+[Service]
+EnvironmentFile=-/etc/default/thanos-query
+User=prometheus
+ExecStart=/usr/bin/thanos query \
+          $THANOS_QUERY_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/thanos/thanos-sidecar.default
+++ b/thanos/thanos-sidecar.default
@@ -1,0 +1,1 @@
+THANOS_SIDECAR_OPTS='--cluster.disable --prometheus.url http://localhost:9090'

--- a/thanos/thanos-sidecar.service
+++ b/thanos/thanos-sidecar.service
@@ -1,0 +1,19 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Thanos Sidecar service.
+Documentation=https://github.com/improbable-eng/thanos/
+After=network.target
+After=prometheus2.service
+
+[Service]
+EnvironmentFile=-/etc/default/thanos-sidecar
+User=prometheus
+ExecStart=/usr/bin/thanos sidecar \
+          --tsdb.path=/var/lib/prometheus/data \
+          $THANOS_SIDECAR_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/thanos/thanos-store.default
+++ b/thanos/thanos-store.default
@@ -1,0 +1,1 @@
+THANOS_STORE_OPTS='--cluster.disable --http-address 0.0.0.0:19191 --grpc-address 0.0.0.0:19090'

--- a/thanos/thanos-store.service
+++ b/thanos/thanos-store.service
@@ -1,0 +1,19 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Thanos Store Gateway service.
+Documentation=https://github.com/improbable-eng/thanos/
+After=network.target
+After=thanos-sidecar.service
+
+[Service]
+EnvironmentFile=-/etc/default/thanos-store
+User=prometheus
+ExecStart=/usr/bin/thanos store \
+          --data-dir=/var/lib/thanos/store \
+          $THANOS_STORE_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,0 +1,88 @@
+%define debug_package %{nil}
+
+Name:	 thanos
+Version: 0.3.2
+Release: 1%{?dist}
+Summary: Highly available Prometheus setup with long term storage capabilities.
+License: ASL 2.0
+URL:     https://github.com/improbable-eng/thanos
+Conflicts: prometheus
+
+Source0: https://github.com/improbable-eng/%{name}/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: thanos-sidecar.service
+Source2: thanos-sidecar.default
+Source3: thanos-store.service
+Source4: thanos-store.default
+Source5: thanos-query.service
+Source6: thanos-query.default
+Source7: thanos-compact.service
+Source8: thanos-compact.default
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
+
+%description
+Thanos is a set of components that can be composed into a highly available
+metric system with unlimited storage capacity, which can be added seamlessly on
+top of existing Prometheus deployments.
+
+Thanos leverages the Prometheus 2.0 storage format to cost-efficiently store
+historical metric data in any object storage while retaining fast query
+latencies. Additionally, it provides a global query view across all Prometheus
+installations and can merge data from Prometheus HA pairs on the fly.
+
+%prep
+%setup -q -n %{name}-%{version}.linux-amd64
+
+%build
+/bin/true
+
+%install
+mkdir -vp %{buildroot}%{_sharedstatedir}/%{name}
+install -D -m 755 thanos %{buildroot}%{_bindir}/thanos
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/thanos-sidecar.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/thanos-sidecar
+install -D -m 644 %{SOURCE3} %{buildroot}%{_unitdir}/thanos-store.service
+install -D -m 644 %{SOURCE4} %{buildroot}%{_sysconfdir}/default/thanos-store
+install -D -m 644 %{SOURCE5} %{buildroot}%{_unitdir}/thanos-query.service
+install -D -m 644 %{SOURCE6} %{buildroot}%{_sysconfdir}/default/thanos-query
+install -D -m 644 %{SOURCE7} %{buildroot}%{_unitdir}/thanos-compact.service
+install -D -m 644 %{SOURCE8} %{buildroot}%{_sysconfdir}/default/thanos-compact
+
+%pre
+getent group prometheus >/dev/null || groupadd -r prometheus
+getent passwd prometheus >/dev/null || \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
+          -c "Prometheus services" prometheus
+exit 0
+
+%post
+%systemd_post thanos-sidecar.service
+%systemd_post thanos-store.service
+%systemd_post thanos-query.service
+%systemd_post thanos-compact.service
+
+%preun
+%systemd_preun thanos-sidecar.service
+%systemd_preun thanos-store.service
+%systemd_preun thanos-query.service
+%systemd_preun thanos-compact.service
+
+%postun
+%systemd_postun thanos-sidecar.service
+%systemd_postun thanos-store.service
+%systemd_postun thanos-query.service
+%systemd_postun thanos-compact.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/%{name}
+%{_unitdir}/thanos-sidecar.service
+%{_unitdir}/thanos-store.service
+%{_unitdir}/thanos-query.service
+%{_unitdir}/thanos-compact.service
+%config(noreplace) %{_sysconfdir}/default/thanos-sidecar
+%config(noreplace) %{_sysconfdir}/default/thanos-store
+%config(noreplace) %{_sysconfdir}/default/thanos-query
+%config(noreplace) %{_sysconfdir}/default/thanos-compact
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/%{name}


### PR DESCRIPTION
Add Thanos RPM package:
https://improbable.io/blog/thanos-prometheus-at-scale

Note: I have disabled clustering (`--cluster.disable`) in service defaults as this feature will shortly be deprecated and is already disabled by default in upcoming Thanos version 0.4.x, thus it doesn't make much sense to rely on this feature on new deployments.