### PR TITLE
node_exporter version bump

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -29,7 +29,7 @@ packages:
       static:
         <<: *default_static_context
         # Remove release line below to Revert release to 1 when version changes 
-        version: 0.17.0
+        version: 0.18.0
         release: 2
         license: ASL 2.0
         URL: https://github.com/prometheus/node_exporter


### PR DESCRIPTION
Rel. 0.18.0

https://github.com/prometheus/node_exporter/releases/tag/v0.18.0

Breaking changes

    Renamed interface label to device in netclass collector for consistency with
    other network metrics #1224
    The cpufreq metrics now separate the cpufreq and scaling data based on what the driver provides. #1248
    The labels for the network_up metric have changed, see issue #1236
    Bonding collector now uses mii_status instead of operstatus #1124
    Several systemd metrics have been turned off by default to improve performance #1254
    These include unit_tasks_current, unit_tasks_max, service_restart_total, and unit_start_time_seconds
    The systemd collector blacklist now includes automount, device, mount, and slice units by default. #1255

Changes

    [CHANGE] Bonding state uses mii_status #1124
    [CHANGE] Add a limit to the number of in-flight requests #1166
    [CHANGE] Renamed interface label to device in netclass collector #1224
    [CHANGE] Add separate cpufreq and scaling metrics #1248
    [CHANGE] Several systemd metrics have been turned off by default to improve performance #1254
    [CHANGE] Expand systemd collector blacklist #1255
    [CHANGE] Split cpufreq metrics into a separate collector #1253
    [FEATURE] Add a flag to disable exporter metrics #1148
    [FEATURE] Add kstat-based Solaris metrics for boottime, cpu and zfs collectors #1197
    [FEATURE] Add uname collector for FreeBSD #1239
    [FEATURE] Add diskstats collector for OpenBSD #1250
    [FEATURE] Add pressure collector exposing pressure stall information for Linux #1174
    [FEATURE] Add perf exporter for Linux #1274
    [ENHANCEMENT] Add Infiniband counters #1120
    [ENHANCEMENT] Add TCPSynRetrans to netstat default filter #1143
    [ENHANCEMENT] Move network_up labels into new metric network_info #1236
    [ENHANCEMENT] Use 64-bit counters for Darwin netstat
    [BUGFIX] Add fallback for missing /proc/1/mounts #1172
    [BUGFIX] Fix node_textfile_mtime_seconds to work properly on symlinks #1326