### PR TITLE
thanos sidecar: move tsdb.path to defaults so it can be overridden

### DIFF
--- a/thanos/thanos-compact.default
+++ b/thanos/thanos-compact.default
@@ -1,1 +1,1 @@
-THANOS_COMPACT_OPTS='--http-address 0.0.0.0:19191'
+THANOS_COMPACT_OPTS='--data-dir=/var/lib/thanos/compact --http-address=0.0.0.0:19191'

--- a/thanos/thanos-compact.service
+++ b/thanos/thanos-compact.service
@@ -9,7 +9,6 @@ After=network.target
 EnvironmentFile=-/etc/default/thanos-compact
 User=prometheus
 ExecStart=/usr/bin/thanos compact \
-          --tsdb.path=/var/lib/thanos/compact \
           $THANOS_COMPACT_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/thanos/thanos-query.default
+++ b/thanos/thanos-query.default
@@ -1,1 +1,1 @@
-THANOS_QUERY_OPTS='--http-address 0.0.0.0:19192 --grpc-address 0.0.0.0:19092 --store localhost:10901'
+THANOS_QUERY_OPTS='--http-address=0.0.0.0:19192 --grpc-address=0.0.0.0:19092 --store=localhost:10901'

--- a/thanos/thanos-rule.default
+++ b/thanos/thanos-rule.default
@@ -1,1 +1,1 @@
-THANOS_RULE_OPTS='--http-address=0.0.0.0:19902 --grpc-address=0.0.0.0:19901 --rule-file=/etc/prometheus/thanos_alerts.yml --query=localhost:19192'
+THANOS_RULE_OPTS='--data-dir=/var/lib/thanos/rule --http-address=0.0.0.0:19902 --grpc-address=0.0.0.0:19901 --rule-file=/etc/prometheus/thanos_alerts.yml --query=localhost:19192'

--- a/thanos/thanos-rule.service
+++ b/thanos/thanos-rule.service
@@ -9,7 +9,6 @@ After=network.target
 EnvironmentFile=-/etc/default/thanos-rule
 User=prometheus
 ExecStart=/usr/bin/thanos rule \
-          --data-dir=/var/lib/thanos/rule \
           $THANOS_RULE_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/thanos/thanos-sidecar.default
+++ b/thanos/thanos-sidecar.default
@@ -1,1 +1,1 @@
-THANOS_SIDECAR_OPTS='--tsdb.path=/var/lib/prometheus/data --prometheus.url http://localhost:9090'
+THANOS_SIDECAR_OPTS='--tsdb.path=/var/lib/prometheus/data --prometheus.url=http://localhost:9090'

--- a/thanos/thanos-sidecar.default
+++ b/thanos/thanos-sidecar.default
@@ -1,1 +1,1 @@
-THANOS_SIDECAR_OPTS='--prometheus.url http://localhost:9090'
+THANOS_SIDECAR_OPTS='--tsdb.path=/var/lib/prometheus/data --prometheus.url http://localhost:9090'

--- a/thanos/thanos-sidecar.service
+++ b/thanos/thanos-sidecar.service
@@ -10,7 +10,6 @@ After=prometheus2.service
 EnvironmentFile=-/etc/default/thanos-sidecar
 User=prometheus
 ExecStart=/usr/bin/thanos sidecar \
-          --tsdb.path=/var/lib/prometheus/data \
           $THANOS_SIDECAR_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/thanos/thanos-store.default
+++ b/thanos/thanos-store.default
@@ -1,1 +1,1 @@
-THANOS_STORE_OPTS='--http-address 0.0.0.0:19191 --grpc-address 0.0.0.0:19090'
+THANOS_STORE_OPTS='--data-dir=/var/lib/thanos/store --http-address=0.0.0.0:19191 --grpc-address=0.0.0.0:19090'

--- a/thanos/thanos-store.service
+++ b/thanos/thanos-store.service
@@ -10,7 +10,6 @@ After=thanos-sidecar.service
 EnvironmentFile=-/etc/default/thanos-store
 User=prometheus
 ExecStart=/usr/bin/thanos store \
-          --data-dir=/var/lib/thanos/store \
           $THANOS_STORE_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always


### PR DESCRIPTION
tsdb.path needs to be in defaults so it can be overridden - otherwise you will get:

Error parsing commandline arguments: flag 'tsdb.path' cannot be repeated

