### PR TITLE
Update node_exporter to 0.18.1

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -28,9 +28,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        # Remove release line below to Revert release to 1 when version changes 
-        version: 0.18.0
-        release: 2
+        version: 0.18.1
         license: ASL 2.0
         URL: https://github.com/prometheus/node_exporter
         summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.


### PR DESCRIPTION
Changes

    [BUGFIX] Fix incorrect sysctl call in BSD meminfo collector, resulting in broken swap metrics on FreeBSD #1345
    [BUGFIX] Fix rollover bug in mountstats collector #1364