### PR TITLE
Update Thanos to 0.5.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.4.0
+Version: 0.5.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed
#1142 fixed major leak on store LRU cache for index items (postings and series).
#1163 sidecar is no longer blocking for custom Prometheus versions/builds. It only checks if flags return non 404, then it performs optional checks.
#1146 store/bucket: make getFor() work with interleaved resolutions.
#1157 querier correctly handles duplicated stores when some store changes external labels in place.
Added
#1094 Allow configuring the response header timeout for the S3 client.
Changed
#1118 breaking swift: Added support for cross-domain authentication by introducing userDomainID, userDomainName, projectDomainID, projectDomainName.
The outdated terms tenantID, tenantName are deprecated and have been replaced by projectID, projectName.

#1066 Upgrade Thanos ui to Prometheus v2.9.1.

Changes from the upstream:

query:
[ENHANCEMENT] Update moment.js and moment-timezone.js PR #4679
[ENHANCEMENT] Support to query elements by a specific time PR #4764
[ENHANCEMENT] Update to Bootstrap 4.1.3 PR #5192
[BUGFIX] Limit number of merics in prometheus UI PR #5139
[BUGFIX] Web interface Quality of Life improvements PR #5201
rule:
[ENHANCEMENT] Improve rule views by wrapping lines PR #4702
[ENHANCEMENT] Show rule evaluation errors on rules page PR #4457
#1156 Moved CI and docker multistage to Golang 1.12.5 for latest mem alloc improvements.

#1103 Updated go-cos deps. (COS bucket client).

#1149 Updated google Golang API deps (GCS bucket client).

#1190 Updated minio deps (S3 bucket client). This fixes minio retries.

#1133 Use prometheus v2.9.2, common v0.4.0 & tsdb v0.8.0.

Changes from the upstreams:

store gateway:
[ENHANCEMENT] Fast path for EmptyPostings cases in Merge, Intersect and Without.
store gateway & compactor:
[BUGFIX] Fix fd and vm_area leak on error path in chunks.NewDirReader.
[BUGFIX] Fix fd and vm_area leak on error path in index.NewFileReader.
query:
[BUGFIX] Make sure subquery range is taken into account for selection #5467
[ENHANCEMENT] Check for cancellation on every step of a range evaluation. #5131
[BUGFIX] Exponentation operator to drop metric name in result of operation. #5329
[BUGFIX] Fix output sample values for scalar-to-vector comparison operations. #5454
rule:
[BUGFIX] Reload rules: copy state on both name and labels. #5368
Deprecated
#1008 breaking Removed Gossip implementation. All --cluster.* flags removed and Thanos will error out if any is provided.