### PR TITLE
Update Alertmanager to 0.18.0

### DIFF
--- a/alertmanager/alertmanager.spec
+++ b/alertmanager/alertmanager.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    alertmanager
-Version: 0.17.0
+Version: 0.18.0
 Release: 1%{?dist}
 Summary: Prometheus Alertmanager.
 License: ASL 2.0


### PR DESCRIPTION
[CHANGE] Remove quantile labels from Summary metrics. #1921
[CHANGE] [OpsGenie] Move from the deprecated teams field in the configuration to responders. #1863
[CHANGE] [ui] Collapse alert groups on the initial view. #1876
[CHANGE] [Wechat] Set the default API secret to blank. #1888
[CHANGE/BUGFIX] [PagerDuty] Fix embedding of images, the text field in the configuration has been renamed to href. #1931
[ENHANCEMENT] Use persistent HTTP clients. #1904
[ENHANCEMENT] Add alertmanager_cluster_alive_messages_total, alertmanager_cluster_peer_info and alertmanager_cluster_pings_seconds metrics. #1941
[ENHANCEMENT] [api] Add missing metrics for API v2. #1902
[ENHANCEMENT] [Slack] Log error message on retry errors. #1655
[ENHANCEMENT] [ui] Allow to create silences from the alerts filter bar. #1911
[ENHANCEMENT] [ui] Enable auto resize the textarea fields. #1893
[BUGFIX] [amtool] Use scheme, authentication and base path from the URL if present. #1892 #1940
[BUGFIX] [amtool] Support filtering alerts by receiver. #1915
[BUGFIX] [api] Fix /api/v2/alerts with multiple receivers. #1948
[BUGFIX] [PagerDuty] Truncate description to 1024 chars for PagerDuty v1. #1922
[BUGFIX] [ui] Add filtering based off of "active" query param. #1879