### PR TITLE
Bump to Prometheus 2.11.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.10.0
+Version: 2.11.0
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
From upstream:

"
We have just cut the final release of v2.11.0. This contains a number of bug fixes, enhancements and a few features, most prominently the option to compress the write-ahead-log to safe disk space. The full changelog can be found in the GitHub release.

Two things to call out:
* write-ahead-log compression can be enabled with the `--storage.tsdb.wal-compression` flag.
* Alertmanager API version to be used by Prometheus is configured using the `api_version` field in the `alertmanagers` config.
"

https://github.com/prometheus/prometheus/releases/tag/v2.11.0