### PR TITLE
Update to Thanos 0.6.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.5.0
+Version: 0.6.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Added
#1097 Added thanos check rules linter for Thanos rule rules files.

#1253 Add support for specifying a maximum amount of retries when using Azure Blob storage (default: no retries).

#1244 Thanos Compact now exposes new metrics thanos_compact_downsample_total and thanos_compact_downsample_failures_total which are useful to catch when errors happen

#1260 Thanos Query/Rule now exposes metrics thanos_querier_store_apis_dns_provider_results and thanos_ruler_query_apis_dns_provider_results which tell how many addresses were configured and how many were actually discovered respectively

#1248 Add a web UI to show the state of remote storage.

#1217 Thanos Receive gained basic hashring support

#1262 Thanos Receive got a new metric thanos_http_requests_total which shows how many requests were handled by it

#1243 Thanos Receive got an ability to forward time series data between nodes. Now you can pass the hashring configuration via --receive.hashrings-file; the refresh interval --receive.hashrings-file-refresh-interval; the name of the local node's name --receive.local-endpoint; and finally the header's name which is used to determine the tenant --receive.tenant-header.

#1147 Support for the Jaeger tracer has been added!

breaking New common flags were added for configuring tracing: --tracing.config-file and --tracing.config. You can either pass a file to Thanos with the tracing configuration or pass it in the command line itself. Old --gcloudtrace.* flags were removed ⚠️

To migrate over the old --gcloudtrace.* configuration, your tracing configuration should look like this:

---
type: STACKDRIVER
config:
- service_name: 'foo'
  project_id: '123'
  sample_factor: 123
The other type you can use is JAEGER now. The config keys and values are Jaeger specific and you can find all of the information here.

Changed
#1284 Add support for multiple label-sets in Info gRPC service. This deprecates the single Labels slice of the InfoResponse, in a future release backward compatible handling for the single set of Labels will be removed. Upgrading to v0.6.0 or higher is advised.

#1314 Removes http_request_duration_microseconds (Summary) and adds http_request_duration_seconds (Histogram) from http server instrumentation used in Thanos APIs and UIs.

#1287 Sidecar now waits on Prometheus' external labels before starting the uploading process

#1261 Thanos Receive now exposes metrics thanos_http_request_duration_seconds and thanos_http_response_size_bytes properly of each handler

#1274 Iteration limit has been lifted from the LRU cache so there should be no more spam of error messages as they were harmless

#1321 Thanos Query now fails early on a query which only uses external labels - this improves clarity in certain situations

Fixed
#1227 Some context handling issues were fixed in Thanos Compact; some unnecessary memory allocations were removed in the hot path of Thanos Store.

#1183 Compactor now correctly propogates retriable/haltable errors which means that it will not unnecessarily restart if such an error occurs

#1231 Receive now correctly handles SIGINT and closes without deadlocking

#1278 Fixed inflated values problem with sum() on Thanos Query

#1280 Fixed a problem with concurrent writes to a map in Thanos Query while rendering the UI

#1311 Fixed occasional panics in Compact and Store when using Azure Blob cloud storage caused by lack of error checking in client library.

#1322 Removed duplicated closing of the gRPC listener - this gets rid of harmless messages like store gRPC listener: close tcp 0.0.0.0:10901: use of closed network connection when those programs are being closed

Deprecated
#1216 the old "Command-line flags" has been removed from Thanos Query UI since it was not populated and because we are striving for consistency