### PR TITLE
pushgateway version bump

### DIFF
--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 pushgateway
-Version: 0.8.0
+Version: 0.9.0
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:
---
0.9.0 / 2019-07-23

[CHANGE] Web: Update to Bootstrap 4.3.1 and jquery 3.4.1, changing appearance of the web UI to be more in line with the Prometheus server. Also add favicon and remove timestamp column. #261
[CHANGE] Update logging to be in line with other Prometheus projects, using gokit and promlog. #263
[FEATURE] Add optional base64 encoding for label values in the grouping key. #268
[FEATURE] Add ARM container images. #265
[FEATURE] Log errors during scrapes. #267
[BUGFIX] Web: Fixed Content-Type for js and css instead of using /etc/mime.types. #252