### PR TITLE
Pushgateway version bump - 0.9.1

### DIFF
--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 pushgateway
-Version: 0.9.0
+Version: 0.9.1
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0


### PR DESCRIPTION
Upstream bugfix release:
---
[BUGFIX] Make --web.external-url and --web.route-prefix work as documented. #274