### PR TITLE
Update Postgres exporter to 0.5.1

### DIFF
--- a/postgres_exporter/postgres_exporter.spec
+++ b/postgres_exporter/postgres_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    postgres_exporter
-Version: 0.5.0
+Version: 0.5.1
 Release: 1%{?dist}
 Summary: Prometheus exporter for PostgreSQL server metrics
 License: ASL 2.0


### PR DESCRIPTION
Changes:
- Add application_name as a label for pg_stat_replication metrics (#285).