### PR TITLE
specify order of dynamic context sections

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -70,8 +70,8 @@ if __name__ == "__main__":
         # Use the compiled contexts to build the dynamic contexts.
         # Dynamic contexts can use other dynamic contexts as long
         # as they are compiled before.
-        to_process = exporter_config["context"]["dynamic"]
-        for context_name, to_template in to_process.items():
+        for context_name in ["tarball", "sources"]:
+            to_template = exporter_config["context"]["dynamic"][context_name]
             print(context_name)
             if type(to_template) is str:
                 context[context_name] = renderTemplateFromString(


### PR DESCRIPTION
I was tearing my hair out on this one - after my (minor) PR to clean up the autogen_* files with 'make clean', I was getting random build failures.  Turns out the old autogen_* files laying around were concealing a bug.

I eventually figured out the issue was the ordering of the 'dynamic' sections - as the comment says, 'dynamic contexts can use other dynamic contexts as long as they are compiled before' - 'sources' uses 'tarball', but processing order was random.

I've updated it to always process 'tarball' then 'sources'.

The drawback is that we can't add other 'dynamic' contexts w/o a code change, but only the postgres_exporter is overriding the default & that's just setting 'tarball' (and it looks like it doesn't even need to do that).

I also thought about just doing a reverse sort of the dynamic contexts, so 'tarball' would always come before 'sources', but that seemed needlessly obscure.

