### PR TITLE
blackbox_exporter version bump to 0.15.0

### DIFF
--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    blackbox_exporter
-Version: 0.14.0
+Version: 0.15.0
 Release: 1%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:
---

[FEATURE] Adding web.external-url and web.route-prefix flags (#515)
[ENHANCEMENT] Bump default timeout to 2m (#509)
[ENHANCEMENT] Use HTTP request's context, so cancellation works. (#510)
[ENHANCEMENT] Add separate history for expired failed probe results (#517)
[BUGFIX] Handle SIGTERM gracefully (#449)
[BUGFIX] Close configuration file (#467)
[BUGFIX] Use timeout for chooseProtocol (#458)
[BUGFIX] Do not apply offsets for explicit timeouts (#492)
[BUGFIX] Don't put v4 addresses in brackets (#506)
[BUGFIX] Set TLSHandshakeTimeout in HTTP transport (common#179)