### PR TITLE
Bump blackbox_exporter - upstream release

### DIFF
--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    blackbox_exporter
-Version: 0.15.0
+Version: 0.15.1
 Release: 1%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0


### PR DESCRIPTION
---
[BUGFIX] Fix probe log links on front page when route prefix is set (#520)