### PR TITLE
set LimitNOFILE to 65536 for some services

### DIFF
--- a/alertmanager/alertmanager.service
+++ b/alertmanager/alertmanager.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/alertmanager \
           $ALERTMANAGER_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/alertmanager/alertmanager.spec
+++ b/alertmanager/alertmanager.spec
@@ -2,7 +2,7 @@
 
 Name:    alertmanager
 Version: 0.19.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Prometheus Alertmanager.
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}

--- a/blackbox_exporter/blackbox_exporter.service
+++ b/blackbox_exporter/blackbox_exporter.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/default/blackbox_exporter
 User=prometheus
 ExecStart=/usr/bin/blackbox_exporter $BLACKBOX_EXPORTER_OPTS
 Restart=on-failure
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -2,7 +2,7 @@
 
 Name:    blackbox_exporter
 Version: 0.15.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}

--- a/prometheus2/prometheus.service
+++ b/prometheus2/prometheus.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/prometheus \
           $PROMETHEUS_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -2,7 +2,7 @@
 
 Name:		 prometheus2
 Version: 2.12.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io

--- a/snmp_exporter/snmp_exporter.service
+++ b/snmp_exporter/snmp_exporter.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/default/snmp_exporter
 User=prometheus
 ExecStart=/usr/bin/snmp_exporter $SNMP_EXPORTER_OPTS
 Restart=always
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -2,7 +2,7 @@
 
 Name:    snmp_exporter
 Version: 0.15.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}


### PR DESCRIPTION
Bump LimitNOFILE to 65536 for the following packages:
- prometheus2
- alertmanager
- blackbox_exporter
- snmp_exporter

cc: @karlism 
re: #144 