### PR TITLE
adding smokeping_prober

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ sachet \
 statsd_exporter \
 ping_exporter \
 process_exporter \
-memcached_exporter
+memcached_exporter \
+smokeping_prober
 
 .PHONY: $(PACKAGES7)
 

--- a/smokeping_prober/smokeping_prober.default
+++ b/smokeping_prober/smokeping_prober.default
@@ -1,0 +1,2 @@
+# smokeping_prober requires a list of hosts to ping
+SMOKEPING_PROBER_OPTS="localhost"

--- a/smokeping_prober/smokeping_prober.service
+++ b/smokeping_prober/smokeping_prober.service
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Smokeping-style prober for Prometheus
+Documentation=https://github.com/SuperQ/smokeping_prober
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/smokeping_prober
+User=prometheus
+ExecStart=/usr/bin/smokeping_prober $SMOKEPING_PROBER_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/smokeping_prober/smokeping_prober.spec
+++ b/smokeping_prober/smokeping_prober.spec
@@ -1,0 +1,54 @@
+%define debug_package %{nil}
+
+Name:    smokeping_prober
+Version: 0.3.0
+Release: 1%{?dist}
+Summary: Smokeping-style prober for Prometheus
+License: ASL 2.0
+URL:     https://github.com/SuperQ/smokeping_prober
+
+Source0: https://github.com/SuperQ/smokeping_prober/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1: %{name}.service
+Source2: %{name}.default
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
+
+%description
+
+The smokeping-style prober sends a series of ICMP (or UDP) pings to a target and records the responses in Prometheus histogram metrics.
+
+%prep
+%setup -q -n %{name}-%{version}.linux-amd64
+
+%build
+/bin/true
+
+%install
+mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
+
+%pre
+getent group prometheus >/dev/null || groupadd -r prometheus
+getent passwd prometheus >/dev/null || \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
+          -c "Prometheus services" prometheus
+exit 0
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun %{name}.service
+
+%files
+%defattr(-,root,root,-)
+%caps(cap_net_raw=ep) %{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %attr(755, prometheus, prometheus)%{_sharedstatedir}/prometheus


### PR DESCRIPTION
Adding https://github.com/SuperQ/smokeping_prober

"This prober sends a series of ICMP (or UDP) pings to a target and records the responses in Prometheus histogram metrics."