### PR TITLE
Update to Thanos 0.8.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.7.0
+Version: 0.8.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Added
#1619 Thanos sidecar allows to limit min time range for data it exposes from Prometheus.
#1583 Thanos sharding:
Add relabel config (--selector.relabel-config-file and selector.relabel-config) into Thanos Store and Compact components.
Selecting blocks to serve depends on the result of block labels relabeling.
For store gateway, advertise labels from "approved" blocks.
#1540 Thanos Downsample added /-/ready and /-/healthy endpoints.
#1538 Thanos Rule added /-/ready and /-/healthy endpoints.
#1537 Thanos Receive added /-/ready and /-/healthy endpoints.
#1460 Thanos Store Added /-/ready and /-/healthy endpoints.
#1534 Thanos Query Added /-/ready and /-/healthy endpoints.
#1533 Thanos inspect now supports the timeout flag.
#1496 Thanos Receive now supports setting block duration.
#1362 Optional replicaLabels param for /query and
/query_range querier endpoints. When provided overwrite the query.replica-label cli flags.
#1482 Thanos now supports Elastic APM as tracing provider.
#1612 Thanos Rule added resendDelay flag.
#1480 Thanos Receive flushes storage on hashring change.
#1613 Thanos Receive now traces forwarded requests.
Changed
#1362 query.replica-label configuration can be provided more than
once for multiple deduplication labels like: --query.replica-label=prometheus_replica --query.replica-label=service.
#1581 Thanos Store now can use smaller buffer sizes for Bytes pool; reducing memory for some requests.
#1622 & #1590 Updated Go to 2.13.1
#1498 Thanos Receive change flag labels to label to be consistent with other commands.
Fixed
#1525 Thanos now deletes block's file in correct order allowing to detect partial blocks without problems.
#1505 Thanos Store now removes invalid local cache blocks.
#1587 Thanos Sidecar cleanups all cache dirs after each compaction run.
#1582 Thanos Rule correctly parses Alertmanager URL if there is more + in it.
#1544 Iterating over object store is resilient to the edge case for some providers.
#1469 Fixed Azure potential failures (EOF) when requesting more data then blob has.
#1512 Thanos Store fixed memory leak for chunk pool.
#1488 Thanos Rule now now correctly links to query URL from rules and alerts.