### PR TITLE
Pushgateway version bump

### DIFF
--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 pushgateway
-Version: 0.9.1
+Version: 0.10.0
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:

---
[CHANGE] Change of the storage format (necessary for the hash collision bugfix below). #293
[CHANGE] Check pushed metrics immediately and reject them if inconsistent. Successful pushes now result in code 200 (not 202). Failures result in code 400 and are logged at error level. #290
[FEATURE] Shutdown via HTTP request. Enable with --web.enable-lifecycle. #292
[FEATURE] Wipe storage completely via HTTP request and via web UI. Enable with --web.enable-admin-api. #287 #285
[BUGFIX] Rule out hash collisions between metric groups. #293
[BUGFIX] Avoid multiple calls of http.Error in push handler. #291