### PR TITLE
Update Posgres Exporter to 0.7.0

### DIFF
--- a/postgres_exporter/postgres_exporter.spec
+++ b/postgres_exporter/postgres_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    postgres_exporter
-Version: 0.5.1
+Version: 0.7.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for PostgreSQL server metrics
 License: ASL 2.0


### PR DESCRIPTION
v0.6.0

* Add SQL for grant connect (#303)
* Expose pg_current_wal_lsn_bytes (#307)
* [minor] fix landing page content-type (#305)
* Updated lib/pg driver to 1.2.0 in order to support stronger SCRAM-SHA-256 authentication. This drops support for Go < 1.11 and PostgreSQL < 9.4. (#304)
* Provide more helpful default values for tables that have never been vacuumed (#310)
* Add retries to getServer() (#316)
* Fix pg_up metric returns last calculated value without explicit resetting (#291)
* Discover only databases that are not templates and allow connections (#297)
* Add --exclude-databases option (#298)



v0.7.0

Introduces some more significant changes, hence the minor version bump in
such a short time frame.

* Rename pg_database_size to pg_database_size_bytes in queries.yml.
* Add pg_stat_statements to sample queries.yml file.
* Add support for optional namespace caching. (#319)
* Fix some autodiscovery problems (#314) (resolves #308)
* Yaml parsing refactor (#299)
* Don't stop generating fingerprint while encountering value with "=" sign (#318)
(may resolve problems with passwords and special characters).