### PR TITLE
Upstream blackbox_exporter release - 0.16.0

### DIFF
--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:    blackbox_exporter
-Version: 0.15.1
-Release: 2%{?dist}
+Version: 0.16.0
+Release: 1%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}


### PR DESCRIPTION
Upstream release 0.16.0
---
* [ENHANCEMENT] Add probe_http_uncompressed_body_length metric (#535)
* [ENHANCEMENT] Export TLS version (#538)
* [BUGFIX] Better handling of HTTP redirects. (#530)
* [BUGFIX] Fix logging of IP addresseses in resolve code. (#548)