### PR TITLE
Update postgres exporter to 0.8.0

### DIFF
--- a/postgres_exporter/postgres_exporter.spec
+++ b/postgres_exporter/postgres_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    postgres_exporter
-Version: 0.7.0
+Version: 0.8.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for PostgreSQL server metrics
 License: ASL 2.0


### PR DESCRIPTION
* Add a build info metric (#323)
* Re-add pg_stat_bgwriter metrics which were accidentally removed in the previous version. (resolves #336)
* Export pg_stat_archiver metrics (#324)
* Add support for 'DATA_SOURCE_URI_FILE' envvar.
* Resolve #329
* Added new field "master" to queries.yaml. (credit to @sfalkon)
  - If "master" is true, query will be call only on once database in instance
* Change queries.yaml for work with autoDiscoveryDatabases options (credit to @sfalkon)
  - added current database name to metrics because any database in cluster maybe have the same table names
  - added "master" field for query instance metrics.