### PR TITLE
Update SNMP exporter to 0.16.1

### DIFF
--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    snmp_exporter
-Version: 0.15.0
+Version: 0.16.1
 Release: 2%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0


### PR DESCRIPTION
[FEATURE] Support BITS values. (#465)
[ENHANCEMENT] Add option to fail on parse errors in the generator. (#382)
[ENHANCEMENT] Switch logging to go-kit (#447)
[BUGFIX] Handle trailing linefeed in NetSNMP output adding 1 to the error count (#398)