### PR TITLE
version bump of statsd_exporter

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.8.1
+Version: 0.13.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
New upstream release - 0.13.0

We've missed a bunch - some breaking changes in here:

0.13.0 / 2019-12-06

    [ENHANCEMENT] Support sampling factors for all statsd metric types (#264)
    [ENHANCEMENT] Support Librato and InfluxDB labeling formats (#267)

0.12.2 / 2019-07-25

    [BUGFIX] Fix Unix socket handler (#252)
    [BUGFIX] Fix panic under high load (#253)

Thank you to everyone who reported and helped debug these issues!

0.12.1 / 2019-07-08

    [BUGFIX] Renew TTL when a metric receives updates (#246)
    [CHANGE] Reload on SIGHUP instead of watching the file (#243)

0.11.2 / 2019-06-14

    [BUGFIX] Fix TCP handler (#235)

0.11.1 / 2019-06-14

    [ENHANCEMENT] Batch event processing for improved ingestion performance (#227)
    [ENHANCEMENT] Switch Prometheus client to promhttp, freeing the standard HTTP metrics (#233)

With #233, the exporter no longer exports metrics about its own HTTP status. These were not helpful since you could not get them when scraping fails. This allows mapping to metric names like http_requests_total that are useful as application metrics.

0.10.6 / 2019-06-07

    [BUGFIX] Fix mapping collision for metrics with different types, but the same name (#229)

0.10.5 / 2019-05-27

    [BUGFIX] Fix "Error: inconsistent label cardinality: expected 0 label values but got N in prometheus.Labels" (#224)

0.10.4 / 2019-05-20

    [BUGFIX] Revert #218 due to a race condition (#221)

0.10.3 / 2019-05-17

    [ENHANCEMENT] Reduce allocations when escaping metric names (#217)
    [ENHANCEMENT] Reduce allocations when handling packets (#218)
    [ENHANCEMENT] Optimize label sorting (#219)

This release is entirely powered by @claytono. Kudos!

0.10.2 / 2019-05-17

    [CHANGE] Do not run as root in the Docker container by default (#202)
    [FEATURE] Add metric for count of events by action (#193)
    [FEATURE] Add metric for count of distinct metric names (#200)
    [FEATURE] Add UNIX socket listener support (#199)
    [FEATURE] Accept Datadog distributions (#211)
    [ENHANCEMENT] Add a health check to the Docker container (#182)
    [ENHANCEMENT] Allow inconsistent label sets (#194)
    [ENHANCEMENT] Speed up sanitization of metric names (#197)
    [ENHANCEMENT] Enable pprof endpoints (#205)
    [ENHANCEMENT] DogStatsD tag parsing is faster (#210)
    [ENHANCEMENT] Cache mapped metrics (#198)
    [BUGFIX] Fix panic if a mapping resulted in an empty name (#192)
    [BUGFIX] Ensure that there are always default quantiles if using summaries (#212)
    [BUGFIX] Prevent ingesting conflicting metric types that would make scraping fail (#213)

With #192, the count of events rejected because of negative counter increments has moved into the statsd_exporter_events_error_total metric, instead of being lumped in with the different kinds of successful events.

0.9.0 / 2019-03-11

    [ENHANCEMENT] Update the Prometheus client library to 0.9.2 (#171)
    [FEATURE] Metrics can now be expired with a per-mapping TTL (#164)
    [CHANGE] Timers that mapped to a summary are scaled to seconds, just like histograms (#178)

If you are using summaries, all your quantiles and _total will change by a factor of 1000. Adjust your queries and dashboards, or consider switching to histograms altogether.