### PR TITLE
Update to Thanos 0.10.0.

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.9.0
+Version: 0.10.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed

    #1919 Compactor: Fixed potential data loss when uploading older blocks, or upload taking long time while compactor is
    running.

    #1937 Compactor: Improved synchronization of meta JSON files.
    Compactor now properly handles partial block uploads for all operation like retention apply, downsampling and compaction. Additionally:
        Removed thanos_compact_sync_meta_* metrics. Use thanos_blocks_meta_* metrics instead.
        Added thanos_consistency_delay_seconds and thanos_compactor_aborted_partial_uploads_deletion_attempts_total metrics.

    #1936 Store: Improved synchronization of meta JSON files. Store now properly handles corrupted disk cache. Added meta.json sync metrics.

    #1856 Receive: close DBReadOnly after flushing to fix a memory leak.

    #1882 Receive: upload to object storage as 'receive' rather than 'sidecar'.

    #1907 Store: Fixed the duration unit for the metric thanos_bucket_store_series_gate_duration_seconds.

    #1931 Compact: Fixed the compactor successfully exiting when actually an error occurred while compacting a blocks group.

    #1872 Ruler: /api/v1/rules now shows a properly formatted value

    #1945 master container images are now built with Go 1.13

    #1956 Ruler: now properly ignores duplicated query addresses

    #1975 Store Gateway: fixed panic caused by memcached servers selector when there's 1 memcached node

Added

    #1852 Add support for AWS_CONTAINER_CREDENTIALS_FULL_URI by upgrading to minio-go v6.0.44
    #1854 Update Rule UI to support alerts count displaying and filtering.
    #1838 Ruler: Add TLS and authentication support for Alertmanager with the --alertmanagers.config and --alertmanagers.config-file CLI flags. See documentation for further information.
    #1838 Ruler: Add a new --alertmanagers.sd-dns-interval CLI option to specify the interval between DNS resolutions of Alertmanager hosts.
    #1881 Store Gateway: memcached support for index cache. See documentation for further information.
    #1904 Add a skip-chunks option in Store Series API to improve the response time of /api/v1/series endpoint.
    #1910 Query: /api/v1/labels now understands POST - useful for sending bigger requests

Changed

    #1947 Upgraded Prometheus dependencies to v2.15.2. This includes:
        Compactor: Significant reduction of memory footprint for compaction and downsampling process.
        Querier: Accepting spaces between time range and square bracket. e.g [ 5m]
        Querier: Improved PromQL parser performance.

    #1833 --shipper.upload-compacted flag has been promoted to non hidden, non experimental state. More info available here.

    #1867 Ruler: now sets a Thanos/$version User-Agent in requests

    #1887 Service discovery now deduplicates targets between different target groups