### PR TITLE
statsd_exporter upstream release

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.13.0
+Version: 0.14.1
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
0.14.1 released:

    [BUGFIX] Mapper cache poisoning when name is variable (#286)
    [BUGFIX] nil pointer dereference in UDP listener (#287)
    [CHANGE] Switch logging to go-kit (#283)
    [CHANGE] Rename existing metric for mapping cache size (#284)
    [ENHANCEMENT] Add metrics for mapping cache hits (#280)