### PR TITLE
Thanos - upstream release

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.10.0
+Version: 0.10.1
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
10.0.1
---
Fixed

    #2015 Sidecar: Querier /api/v1/series bug fixed when time range was ignored inside sidecar. The bug was noticeable for example when using Grafana template variables.