### PR TITLE
pushgateway - upstream release

### DIFF
--- a/pushgateway/pushgateway.spec
+++ b/pushgateway/pushgateway.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 pushgateway
-Version: 1.0.1
+Version: 1.1.0
 Release: 1%{?dist}
 Summary: Prometheus Pushgateway.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:
---
It adds a new flag --push.disable-consistency-check, which can be used to disable the push-time checks introduced in v0.10. Using this flag is dangerous because it will allow pushing metrics that lead to an inconsistent state of the metrics served by the Pushgateway. After pushing a metric that leads to such inconsistencies, the whole Pushgateway will fail scrapes by Prometheus until the offending metrics are deleted. However, the push-time check has a performance cost, and thus disabling it is required in situations where pushes happen very frequently and the Pushgateway has to store a lot of metrics. Arguably, those situations only happen when the Pushgateway is used in ways it is not intended for (cf. the documented best practices). However, to not break the usage pattern some users adopted prior to v0.10, the --push.disable-consistency-check has been introduced. Please enjoy responsibly!
1.1.0 / 2020-01-27

    [FEATURE] Add flag --push.disable-consistency-check. #318