### PR TITLE
add centos8 support

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 This script generates spec, unit and init files for CentOS build_filess.

--- a/sachet/sachet.spec
+++ b/sachet/sachet.spec
@@ -1,3 +1,6 @@
+%define debug_package %{nil}
+%undefine _missing_build_ids_terminate_build
+
 Name:       sachet
 Version:    0.2.0
 Release:    1%{?dist}


### PR DESCRIPTION
Placeholder PR for cento8 package build. Depends on https://github.com/zoonage/centos-rpm-builder-docker/pull/4 bring merged and the centos8 build images being uploaded to quay.io.