### PR TITLE
graphite_exporter upstream release - 0.7.0

### DIFF
--- a/graphite_exporter/graphite_exporter.spec
+++ b/graphite_exporter/graphite_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    graphite_exporter
-Version: 0.6.2
+Version: 0.7.0
 Release: 1%{?dist}
 Summary: Prometheus Graphite exporter.
 License: ASL 2.0


### PR DESCRIPTION
---
0.7.0 / 2020-02-28

@prombot prombot released this 1 hour ago

    [CHANGE] Update logging library and flags (#109)
    [CHANGE] Updated prometheus golang client and statsd mapper dependency. (#113)

This release updates several dependencies. Logging-related flags have changed.

The metric mapping library is now at the level of statsd exporter 0.14.1, bringing in various performance improvements. See the statsd exporter changelog for the detailed changes.