### PR TITLE
Update to Thanos 0.11.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.10.1
+Version: 0.11.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed
#2033 Minio-go: Fixed Issue #1494 support Web Identity providers for IAM credentials for AWS EKS.
#1985 Store Gateway: Fixed case where series entry is larger than 64KB in index.
#2051 Ruler: Fixed issue where ruler does not expose shipper metrics.
#2101 Ruler: Fixed bug where thanos_alert_sender_errors_total was not registered.
#1789 Store Gateway: Improve timeouts.
#2139 Properly handle SIGHUP for reloading.
#2040 UI: Fix URL of alerts in Ruler
#2033 Ruler: Fix tracing in Thanos Ruler
Added
#2003 Query: Support downsampling for /series.
#1952 Store Gateway: Implemented binary index header. This significantly reduces resource consumption (memory, CPU, net bandwidth) for startup and data loading processes as well as baseline memory. This means that adding more blocks into object storage, without querying them will use almost no resources. This, however, still means that querying large amounts of data will result in high spikes of memory and CPU use as before, due to simply fetching large amounts of metrics data. Since we fixed baseline, we are now focusing on query performance optimizations in separate initiatives. To enable experimental index-header mode run store with hidden experimental.enable-index-header flag.
#2009 Store Gateway: Minimum age of all blocks before they are being read. Set it to a safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.
#1963 Mixin: Add Thanos Ruler alerts.
#1984 Query: Add cache-control header to not cache on error.
#1870 UI: Persist settings in query.
#1969 Sidecar: allow setting http connection pool size via flags.
#1967 Receive: Allow local TSDB compaction.
#1939 Ruler: Add TLS and authentication support for query endpoints with the --query.config and --query.config-file CLI flags. See documentation for further information.
#1982 Ruler: Add support for Alertmanager v2 API endpoints.
#2030 Query: Add thanos_proxy_store_empty_stream_responses_total metric for number of empty responses from stores.
#2049 Tracing: Support sampling on Elastic APM with new sample_rate setting.
#2008 Querier, Receiver, Sidecar, Store: Add gRPC health check endpoints.
#2145 Tracing: track query sent to prometheus via remote read api.
Changed
#1970 breaking Receive: Use gRPC for forwarding requests between peers. Note that existing values for the --receive.local-endpoint flag and the endpoints in the hashring configuration file must now specify the receive gRPC port and must be updated to be a simple host:port combination, e.g. 127.0.0.1:10901, rather than a full HTTP URL, e.g. http://127.0.0.1:10902/api/v1/receive.
#1933 Add a flag --tsdb.wal-compression to configure whether to enable tsdb wal compression in ruler and receiver.
#2021 Rename metric thanos_query_duplicated_store_address to thanos_query_duplicated_store_addresses_total and thanos_rule_duplicated_query_address to thanos_rule_duplicated_query_addresses_total.