### PR TITLE
statsd_exporter upstream release - 0.15.0

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.14.1
+Version: 0.15.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:

https://github.com/prometheus/statsd_exporter/releases/tag/v0.15.0

---


    [ENHANCEMENT] Allow setting granularity for summary metrics (#290)
    [ENHANCEMENT] Support a random-replacement cache invalidation strategy (#281

To facilitate the expanded settings for summaries, the configuration format changes from

mappings:
- match: …
  timer_type: summary
  quantiles:
    - quantile: 0.99
      error: 0.001
    - quantile: 0.95
      error: 0.01
  …

to

mappings:
- match: …
  timer_type: summary
  summary_options:
    quantiles:
      - quantile: 0.99
        error: 0.001
      - quantile: 0.95
        error: 0.01
      …
    max_summary_age: 30s
    summary_age_buckets: 3
    stream_buffer_size: 1000
  …

For consistency, the format for histogram buckets also changes from

mappings:
- match: …
  timer_type: histogram
  buckets: [ 0.01, 0.025, 0.05, 0.1 ]

to

mappings:
- match: …
  timer_type: histogram
  histogram_options:
    buckets: [ 0.01, 0.025, 0.05, 0.1 ]

Transitionally, the old format will still work but is deprecated. The new
settings are optional.

For users of the mapper
as a library, this is a breaking change. To adjust your code, replace
mapping.Buckets with mapping.HistogramOptions.Buckets and
mapping.Quantiles with mapping.SummaryOptions.Quantiles.