### PR TITLE
Update to Prometheus 2.17.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.16.0
+Version: 2.17.0
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
This release implements isolation in TSDB. API queries and recording rules are
guaranteed to only see full scrapes and full recording rules. This comes with a
certain overhead in resource usage. Depending on the situation, there might be
some increase in memory usage, CPU usage, or query latency.

[FEATURE] TSDB: Support isolation #6841
[ENHANCEMENT] PromQL: Allow more keywords as metric names #6933
[ENHANCEMENT] React UI: Add normalization of localhost URLs in targets page #6794
[ENHANCEMENT] Remote read: Read from remote storage concurrently #6770
[ENHANCEMENT] Rules: Mark deleted rule series as stale after a reload #6745
[ENHANCEMENT] Scrape: Log scrape append failures as debug rather than warn #6852
[ENHANCEMENT] TSDB: Improve query performance for queries that partially hit the head #6676
[ENHANCEMENT] Consul SD: Expose service health as meta label #5313
[ENHANCEMENT] EC2 SD: Expose EC2 instance lifecycle as meta label #6914
[ENHANCEMENT] Kubernetes SD: Expose service type as meta label for K8s service role #6684
[ENHANCEMENT] Kubernetes SD: Expose label_selector and field_selector #6807
[ENHANCEMENT] Openstack SD: Expose hypervisor id as meta label #6962
[BUGFIX] PromQL: Do not escape HTML-like chars in query log #6834 #6795
[BUGFIX] React UI: Fix data table matrix values #6896
[BUGFIX] React UI: Fix new targets page not loading when using non-ASCII characters #6892
[BUGFIX] Remote read: Fix duplication of metrics read from remote storage with external labels #6967 #7018
[BUGFIX] Remote write: Register WAL watcher and live reader metrics for all remotes, not just the first one #6998
[BUGFIX] Scrape: Prevent removal of metric names upon relabeling #6891
[BUGFIX] Scrape: Fix 'superfluous response.WriteHeader call' errors when scrape fails under some circonstances #6986
[BUGFIX] Scrape: Fix crash when reloads are separated by two scrape intervals #7011