### PR TITLE
Update Thanos to 0.12.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.11.0
+Version: 0.12.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed
#2288 Ruler: fixes issue #2281, a bug causing incorrect parsing of query address with path prefix.
#2238 Ruler: fixed issue #2204, where a bug in alert queue signaling filled up the queue and alerts were dropped.
#2231 Bucket Web: sort chunks by thanos.downsample.resolution for better grouping.
#2254 Bucket: fix issue where metrics were registered multiple times in bucket replicate.
#2271 Bucket Web: fixed issue #2260, where the bucket passes null when storage is empty.
#2339 Query: fix a bug where --store.unhealthy-timeout was never respected.
#2208 Query and Rule: fix handling of web.route-prefix to correctly handle / and prefixes that do not begin with a /.
#2311 Receive: ensure receive component serves TLS when TLS configuration is provided.
#2319 Query: fixed inconsistent naming of metrics.
#2390 Store: fixed bug that was causing all posting offsets to be used instead of only 1/32 as intended; added hidden flag to control this behavior.
#2393 Store: fixed bug causing certain not-existing label values queried to fail with "invalid-size" error from binary header.
#2382 Store: fixed bug causing partial writes of index-header.
#2383 Store: handle expected errors correctly, e.g. do not increment failure counters.
Added
#2252 Query: add new --store-strict flag. More information available here.
#2265 Compact: add --wait-interval to specify compaction wait interval between consecutive compact runs when --wait is enabled.
#2250 Compact: enable vertical compaction for offline deduplication (experimental). Uses --deduplication.replica-label flag to specify the replica label on which to deduplicate (hidden). Please note that this uses a NAIVE algorithm for merging (no smart replica deduplication, just chaining samples together). This works well for deduplication of blocks with precisely the same samples like those produced by Receiver replication. We plan to add a smarter algorithm in the following weeks.
#1714 Compact: the compact component now exposes the bucket web UI when it is run as a long-lived process.
#2304 Store: added max_item_size configuration option to memcached-based index cache. This should be set to the max item size configured in memcached (-I flag) in order to not waste network round-trips to cache items larger than the limit configured in memcached.
#2297 Store: add --experimental.enable-index-cache-postings-compression flag to enable re-encoding and compressing postings before storing them into the cache. Compressed postings take about 10% of the original size.
#2357 Compact and Store: the compact and store components now serve the bucket UI on :<http-port>/loaded, which shows exactly the blocks that are currently seen by compactor and the store gateway. The compactor also serves a different bucket UI on :<http-port>/global, which shows the status of object storage without any filters.
#2166 Bucket Web: improve the tooltip for the bucket UI; it was reconstructed and now exposes much more information about blocks.
#2172 Store: add support for sharding the store component based on the label hash.
#2113 Bucket: added thanos bucket replicate command to replicate blocks from one bucket to another.
#1922 Docs: create a new document to explain sharding in Thanos.
#2230 Store: optimize conversion of labels.
Changed
#2136 breaking Store, Compact, Bucket: schedule block deletion by adding deletion-mark.json. This adds a consistent way for multiple readers and writers to access object storage.
Since there are no consistency guarantees provided by some Object Storage providers, this PR adds a consistent lock-free way of dealing with Object Storage irrespective of the choice of object storage. In order to achieve this co-ordination, blocks are not deleted directly. Instead, blocks are marked for deletion by uploading the deletion-mark.json file for the block that was chosen to be deleted. This file contains Unix time of when the block was marked for deletion. If you want to keep existing behavior, you should add --delete-delay=0s as a flag.
#2090 breaking Downsample command: the downsample command has moved and is now a sub-command of the thanos bucket sub-command; it cannot be called via thanos downsample any more.
#2294 Store: optimizations for fetching postings. Queries using =~".*" matchers or negation matchers (!=... or !~...) benefit the most.
#2301 Ruler: exit with an error when initialization fails.
#2310 Query: report timespan 0 to 0 when discovering no stores.
#2330 Store: index-header is no longer experimental. It is enabled by default for store Gateway. You can disable it with new hidden flag: --store.disable-index-header. The --experimental.enable-index-header flag was removed.
#1848 Ruler: allow returning error messages when a reload is triggered via HTTP.
#2270 All: Thanos components will now print stack traces when they error out.