### PR TITLE
Update Prometheus to 2.17.2

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.17.1
+Version: 2.17.2
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
[BUGFIX] Federation: Register federation metrics #7081
[BUGFIX] PromQL: Fix panic in parser error handling #7132
[BUGFIX] Rules: Fix reloads hanging when deleting a rule group that is being evaluated #7138
[BUGFIX] TSDB: Fix a memory leak when prometheus starts with an empty TSDB WAL #7135
[BUGFIX] TSDB: Make isolation more robust to panics in web handlers #7129 #7136