### PR TITLE
Switch to postgres system account.

### DIFF
--- a/postgres_exporter/postgres_exporter.service
+++ b/postgres_exporter/postgres_exporter.service
@@ -7,7 +7,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/default/postgres_exporter
-User=prometheus
+User=postgres
 ExecStart=/usr/bin/postgres_exporter $POSTGRES_EXPORTER_OPTS
 Restart=on-failure
 

--- a/postgres_exporter/postgres_exporter.spec
+++ b/postgres_exporter/postgres_exporter.spec
@@ -2,7 +2,7 @@
 
 Name:    postgres_exporter
 Version: 0.8.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Prometheus exporter for PostgreSQL server metrics
 License: ASL 2.0
 URL:     https://github.com/wrouesnel/%{name}
@@ -30,13 +30,17 @@ mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
 install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
 install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
 install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
-install -D -m 640 %{SOURCE3} %{buildroot}%{_sysconfdir}/prometheus/%{name}_queries.yaml
+install -D -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/prometheus/%{name}_queries.yaml
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
   useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
           -c "Prometheus services" prometheus
+getent group postgres >/dev/null || groupadd -r postgres 
+getent passwd postgres >/dev/null || \
+  useradd -r -g postgres -d /var/lib/pgsql -s /bin/bash \
+          -c "PostgreSQL Server" postgres
 exit 0
 
 %post


### PR DESCRIPTION
Replacement for:
https://github.com/lest/prometheus-rpm/pull/209
https://github.com/lest/prometheus-rpm/pull/210
https://github.com/lest/prometheus-rpm/pull/211

Switches `postgres_exporter` to `postgres` system account so that it can connect to local PostgreSQL server instance.