### PR TITLE
Switch keepalived exporter to root user

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -135,6 +135,9 @@ packages:
         <<: *default_static_context
         version: 0.4.0
         license: ASL 2.0
+        user: root
+        group: root
+        release: 2
         URL: https://github.com/gen2brain/keepalived_exporter
         package: '%{name}-%{version}-amd64'
         summary: Prometheus exporter for Keepalived metrics


### PR DESCRIPTION
Keepalived exporter requires to be run as root since it needs to send SIGUSR1 to `keepalived` process, which runs as root on CentOS