### PR TITLE
Update Thanos to 0.12.2

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.12.1
+Version: 0.12.2
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed
    #2459 Compact: Fixed issue with old blocks being marked and deleted in a (slow) loop.
    #2533 Rule: do not wrap reload endpoint with /. Makes /-/reload accessible again when no prefix has been specified.