### PR TITLE
Add manual package CentOS 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ jobs:
     - env: BUILD_TARGET=auto8 PUBLISH_TARGET=publish8
     - env: BUILD_TARGET=auto7 PUBLISH_TARGET=publish7
     - env: BUILD_TARGET=auto6 PUBLISH_TARGET=publish6
-    - env: BUILD_TARGET=7 PUBLISH_TARGET=publish7
+    - env: BUILD_TARGET=manual8 PUBLISH_TARGET=publish8
+    - env: BUILD_TARGET=manual7 PUBLISH_TARGET=publish7

--- a/sachet/sachet.spec
+++ b/sachet/sachet.spec
@@ -1,5 +1,5 @@
 Name:       sachet
-Version:    0.2.0
+Version:    0.2.3
 Release:    1%{?dist}
 Summary:    SMS alerts for Prometheus Alertmanager
 License:    BSD
@@ -8,8 +8,6 @@ Source0:    https://github.com/messagebird/%{name}/releases/download/%{version}/
 Source1:    %{name}.service
 Source2:    %{name}.default
 Source3:    %{name}.yml
-
-Requires:   make
 
 %description
 Sachet (or सचेत) is Hindi for conscious. Sachet is an SMS alerting tool for the Prometheus Alertmanager.

--- a/sachet/sachet.spec
+++ b/sachet/sachet.spec
@@ -1,3 +1,5 @@
+%define debug_package %{nil}
+
 Name:       sachet
 Version:    0.2.3
 Release:    1%{?dist}


### PR DESCRIPTION
Add CentOS 8 support for manual packages.

Update Sachet to 0.2.3 and remove `make` dependency.

Resolves https://github.com/lest/prometheus-rpm/issues/152