### PR TITLE
Update to Prometheus 2.18.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.17.2
+Version: 2.18.0
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
[CHANGE] Federation: Only use local TSDB for federation (ignore remote read). #7077
[CHANGE] Rules: rule_evaluations_total and rule_evaluation_failures_total have a rule_group label now. #7094
[FEATURE] Tracing: Added experimental Jaeger support #7148
[ENHANCEMENT] TSDB: Significantly reduce WAL size kept around after a block cut. #7098
[ENHANCEMENT] Discovery: Add architecture meta label for EC2. #7000
[BUGFIX] UI: Fixed wrong MinTime reported by /status. #7182
[BUGFIX] React UI: Fixed multiselect legend on OSX. #6880
[BUGFIX] Remote Write: Fixed blocked resharding edge case. #7122
[BUGFIX] Remote Write: Fixed remote write not updating on relabel configs change. #7073