### PR TITLE
Update SSL exporter to 1.0.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -113,6 +113,7 @@ packages:
         license: ASL 2.0
         URL: https://github.com/ribbybibby/ssl_exporter
         package: '%{name}_%{version}_linux_amd64'
+        tarball_has_subdirectory: False
         summary: Prometheus exporter for SSL certificates.
         description: Prometheus exporter for SSL certificates.
   bind_exporter:

--- a/templating.yaml
+++ b/templating.yaml
@@ -109,10 +109,10 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.6.0
+        version: 1.0.0
         license: ASL 2.0
         URL: https://github.com/ribbybibby/ssl_exporter
-        summary: Prometheus exporter for SSL certificates
+        summary: Prometheus exporter for SSL certificates.
         description: Prometheus exporter for SSL certificates.
   bind_exporter:
     build_steps:

--- a/templating.yaml
+++ b/templating.yaml
@@ -112,6 +112,7 @@ packages:
         version: 1.0.0
         license: ASL 2.0
         URL: https://github.com/ribbybibby/ssl_exporter
+        package: '%{name}_%{version}_linux_amd64'
         summary: Prometheus exporter for SSL certificates.
         description: Prometheus exporter for SSL certificates.
   bind_exporter:


### PR DESCRIPTION
Changelog
b7cdf62 update release process notes in README
c98cb10 cut 1.0.0 release
66ae153 add a grafana dashboard (#25)
13519dd add goreleaser
e3477cf add TLS version metric (#24)
80765ab add a github action to build the docker image
78ce406 fix tests
11e3e4c move metadata out of metrics and into labels
000c8a8 add tests for notBefore and notAfter
486b47f describe not before metric
0983ffd use the parsed target when connecting with the http client
874f02f fix docker instructions in README
5b927d8 fix example queries in README
81ff845 bump go version in .promu.yaml
0089529 build with go 1.13 explicitly in the Dockerfile
0a4a402 remove unnecessary STATICCHECK_IGNORE from Makefile
6d5223c use promhttp.Handler()
81504f6 make it work with Go 1.13