### PR TITLE
Update Process Exporter to 0.6.0

### DIFF
--- a/process_exporter/process_exporter.spec
+++ b/process_exporter/process_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 process_exporter
-Version: 0.5.0
+Version: 0.6.0
 Release: 1%{?dist}
 Summary: Process exporter for Prometheus.
 License: MIT


### PR DESCRIPTION
Changelog:
f91ecbb PID and StartTime are now available as templates to use in defining a groupname.