### PR TITLE
Update SNMP exporter to 0.18.0

### DIFF
--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:    snmp_exporter
-Version: 0.17.0
-Release: 2%{?dist}
+Version: 0.18.0
+Release: 1%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}


### PR DESCRIPTION
[FEATURE] Allow lookup chaining in a basic way (#489)
[BUGFIX] Reduce and fix timeouts for SNMP requests (#511)