### PR TITLE
Update consul_exporter - upstream release 0.7.0

### DIFF
--- a/consul_exporter/consul_exporter.spec
+++ b/consul_exporter/consul_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    consul_exporter
-Version: 0.6.0
+Version: 0.7.0
 Release: 1%{?dist}
 Summary: Prometheus Consul exporter.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:
---
Simon Pasquier <pasquier.simon@gmail.com>
	
Jun 11, 2020, 8:42 AM (4 days ago)
	
to prometheus-announce
Hello all,

We're pleased to announce the release of consul_expoter v0.7.0 [1].

* [FEATURE] Add consul_service_checks metric to link checks with their
services. #162
* [ENHANCEMENT] Add --consul.request-limit flag to limit the maximum
number of concurrent requests to Consul. #164