### PR TITLE
Update node exporter to 1.0.1

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -28,7 +28,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 1.0.0
+        version: 1.0.1
         license: ASL 2.0
         URL: https://github.com/prometheus/node_exporter
         summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.


### PR DESCRIPTION
[BUGFIX] filesystem_freebsd: Fix label values #1728
[BUGFIX] Update prometheus/procfs to fix log noise #1735
[BUGFIX] Fix build tags for collectors #1745
[BUGFIX] Handle no data from powersupplyclass #1747, #1749