### PR TITLE
redis_exporter - upstream releases

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -55,7 +55,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.6.0
+        version: 1.8.0
         license: ASL 2.0
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, and 5.x


### PR DESCRIPTION
Updating redis_exporter from 1.6.0 to 1.8.0
---

v1.8.0
    PR #393 - Allow passing Root CA Cert file for TLS connections (thx @SarjakSShah )
v1.7.0
    PR #392 - Add support for Redis 6 username auth (thx @k3a )
v1.6.1
    PR #383 Fix missing labels for some replication metrics (thx @yz1509 )