### PR TITLE
Update Nginx exporter to 0.8.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -94,7 +94,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.7.0
+        version: 0.8.0
         license: ASL 2.0
         package: 'nginx-prometheus-exporter-%{version}-linux-amd64'
         URL: https://github.com/nginxinc/nginx-prometheus-exporter


### PR DESCRIPTION
CHANGES:

103: Switch to gcr.io/distroless/static image. Use a non-root user to run the exporter process by default. Thanks to Alex SZAKALY.
Update Go version to 1.14
BUGFIXES:

99: Fix link to metrics path. Thanks to Yoan Blanc.
101: docs: fix dockerfile link. Thanks to Eric Carboni.