### PR TITLE
Update to haproxy_exporter 0.11.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -70,7 +70,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.10.0
+        version: 0.11.0
         license: ASL 2.0
         URL: https://github.com/prometheus/haproxy_exporter
         summary: This is a simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption.


### PR DESCRIPTION
* [CHANGE] Switch logging to go-kit #171
* [CHANGE] Fix metric types #182
* [CHANGE] Fix unit of time metric #183
* [FEATURE] Add filtering on server status #160
* [ENHANCEMENT] Add compression and server selection metrics #154
* [ENHANCEMENT] Add client/server abort metrics #167
* [ENHANCEMENT] Add version info metric (when using UNIX sockets) #180

Note: This release fixes the metric types of counters and renames the following metrics:

* `haproxy_exporter_csv_parse_failures` -> `haproxy_exporter_csv_parse_failures_total`
* `haproxy_exporter_total_scrapes` -> `haproxy_exporter_scrapes_total`
* `haproxy_server_check_duration_milliseconds` -> `haproxy_server_check_duration_seconds`