### PR TITLE
Update statsd_exporter to 0.17.0

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.15.0
+Version: 0.17.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
---

0.17.0 / 2020-06-26

    [CHANGE] Support non-timer distributions without unit conversion (#314)
    [ENHANCEMENT] Offline configuration check (#312)
    [ENHANCEMENT] Support the SignalFX tagging extension (#315)
    [BUGFIX] Allow matching single-letter metric name components (#309)

Distribution and histogram events (type d, h) are now treated as distinct from timer events (type ms).
Their values are observed as they are, while timer events are converted from milliseconds to seconds.

To reflect this generalization, the observer_type mapping option replaces timer_type.
Similary, change match_metric_type: timer to match_metric_type: observer.
The old name remains available for compatibility.

For users of the mapper library, the ObserverEvent replaces TimerEvent.
For timer metrics, it is emitted by the mapper already converted to seconds.



0.16.0 / 2020-05-29

    [CHANGE] Break out much of the exporter into reusable packages (#298)
    [ENHANCEMENT] Log ingested lines at debug level (#305)

This release mainly consists of an internal reorganization of the exporter.
This should not have any impact on users of the binary, if it does, please file
an issue.

For users of the existing library packages, nothing changes.

There are now multiple new packages available, exposing functionality that had
been locked away in the main package. Consider the interfaces of these
libraries preliminary; we will change them as we gain experience in how they
are used.