### PR TITLE
Update SSL exporter to 2.0.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -109,7 +109,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 1.0.1
+        version: 2.0.0
         license: ASL 2.0
         URL: https://github.com/ribbybibby/ssl_exporter
         package: '%{name}_%{version}_linux_amd64'


### PR DESCRIPTION
This release modifies the way the exporter is configured to use a modules/probers structure as seen in the blackbox_exporter.

This should be a no-op for the majority of users, however please note the following:

The --tls.insecure, --tls.cacert, --tls.client-auth, --tls.cert and --tls.key options have been removed. Please define a module with the corresponding TLS options instead. Refer to the example.
If you were relying on http proxying or other http client features, you will need to update your scrape config to use the https prober module, rather than relying on the exporter comprehending the scheme of the target. This is covered in the README.
Some new features have been introduced as well:

Support for setting TLS servername
STARTTLS support for smtp, imap and ftp
Defining a http proxy url explicitly on a per-module basis
Changelog
b2ed4e6 release 2.0.0
89eff28 Add starttls for smtp, imap and ftp (#36)
1c8bd16 Add proxy_url parameter to https configuration (#35)
801179e Move to a modules/probers model, like the blackbox_exporter. (#34)