### PR TITLE
ssl_exporter: include sample config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ smokeping_prober \
 exporter_exporter \
 iperf3_exporter \
 couchbase_exporter \
-junos_exporter
+junos_exporter \
+ssl_exporter
 
 AUTO_GENERATED = node_exporter \
 pushgateway \
@@ -29,7 +30,6 @@ redis_exporter \
 haproxy_exporter \
 kafka_exporter \
 nginx_exporter \
-ssl_exporter \
 bind_exporter \
 keepalived_exporter \
 jolokia_exporter

--- a/ssl_exporter/ssl_exporter.default
+++ b/ssl_exporter/ssl_exporter.default
@@ -1,1 +1,1 @@
-SSL_EXPORTER_OPTS=""
+SSL_EXPORTER_OPTS=--config.file=/etc/prometheus/ssl_exporter.yml

--- a/ssl_exporter/ssl_exporter.service
+++ b/ssl_exporter/ssl_exporter.service
@@ -1,0 +1,20 @@
+# -*- mode: conf -*-
+
+[Unit]
+
+Description=Prometheus exporter for SSL certificates.
+Documentation=https://github.com/ribbybibby/ssl_exporter
+After=network.target
+
+
+[Service]
+
+EnvironmentFile=-/etc/default/ssl_exporter
+User=prometheus
+ExecStart=/usr/bin/ssl_exporter $SSL_EXPORTER_OPTS
+Restart=on-failure
+
+
+[Install]
+
+WantedBy=multi-user.target

--- a/ssl_exporter/ssl_exporter.spec
+++ b/ssl_exporter/ssl_exporter.spec
@@ -1,0 +1,54 @@
+%define debug_package %{nil}
+
+Name:       ssl_exporter
+Version:    2.0.0
+Release:    2%{?dist}
+Summary:    Prometheus exporter for SSL certificates.
+License:    ASL 2.0
+URL:        https://github.com/ribbybibby/ssl_exporter
+
+Source0:    https://github.com/ribbybibby/ssl_exporter/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz
+Source1:    %{name}.service
+Source2:    %{name}.default
+Source3:    %{name}.yml
+
+# Requires:   make
+
+%description
+Prometheus exporter for SSL certificates.
+
+%prep
+%setup -q -D -c %{name}_%{version}_linux_amd64
+
+%build
+/bin/true
+
+%install
+# mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
+install -D -m 640 %{SOURCE3} %{buildroot}%{_sysconfdir}/prometheus/ssl_exporter.yml
+
+%pre
+getent group prometheus >/dev/null || groupadd -r prometheus
+getent passwd prometheus >/dev/null || \
+  useradd -r -g prometheus -d %{_sharedstatedir}/prometheus -s /sbin/nologin \
+          -c "Prometheus services" prometheus
+exit 0
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun %{name}.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%config(noreplace) %attr(644, root, root)%{_sysconfdir}/prometheus/ssl_exporter.yml

--- a/ssl_exporter/ssl_exporter.yml
+++ b/ssl_exporter/ssl_exporter.yml
@@ -1,0 +1,27 @@
+modules:
+  https:
+    prober: https
+  https_insecure:
+    prober: https
+    tls_config:
+      insecure_skip_verify: true
+  https_proxy:
+    prober: https
+    https:
+      proxy_url: "socks5://localhost:8123"
+  tcp:
+    prober: tcp
+  tcp_servername:
+    prober: tcp
+    tls_config:
+      server_name: example.com
+  tcp_client_auth:
+    prober: tcp
+    tls_config:
+      ca_file: /etc/tls/ca.crt
+      cert_file: /etc/tls/tls.crt
+      key_file: /etc/tls/tls.key
+  tcp_smtp_starttls:
+    prober: tcp
+    tcp:
+      starttls: smtp

--- a/templating.yaml
+++ b/templating.yaml
@@ -102,20 +102,6 @@ packages:
         fix_name: nginx-prometheus-exporter
         summary: NGINX Prometheus Exporter for NGINX and NGINX Plus.
         description: NGINX Prometheus Exporter for NGINX and NGINX Plus.
-  ssl_exporter:
-    build_steps:
-      <<: *default_build_steps
-    context:
-      <<: *default_context
-      static:
-        <<: *default_static_context
-        version: 2.0.0
-        license: ASL 2.0
-        URL: https://github.com/ribbybibby/ssl_exporter
-        package: '%{name}_%{version}_linux_amd64'
-        tarball_has_subdirectory: False
-        summary: Prometheus exporter for SSL certificates.
-        description: Prometheus exporter for SSL certificates.
   bind_exporter:
     build_steps:
       <<: *default_build_steps


### PR DESCRIPTION
ssl_exporter 2.x switched to using a blackbox-style config file, specifying various modules for skipping TLS verification, setting SNI, etc.

Include the sample config file from the repo in the package.