### PR TITLE
Update memcached exporter to 0.7.0

### DIFF
--- a/memcached_exporter/memcached_exporter.spec
+++ b/memcached_exporter/memcached_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:    memcached_exporter
-Version: 0.6.0
-Release: 2%{?dist}
+Version: 0.7.0
+Release: 1%{?dist}
 Summary: Prometheus memcached exporter.
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}


### PR DESCRIPTION
[CHANGE] Switch logging to go-kit #73
[CHANGE] Register memcached_lru_crawler_starts_total metric correctly (formerly namespace_lru_crawler_starts) #83
[ENHANCEMENT] Add memcached_time_seconds metric #74
[ENHANCEMENT] Add slab metrics related to hot/warm/cold/temp LRUs #76
[BUGFIX] Fix memcached_slab_mem_requested_bytes metric in newer memcached versions #70