### PR TITLE
Update JMX exporter to 0.13.0

### DIFF
--- a/jmx_exporter/jmx_exporter.spec
+++ b/jmx_exporter/jmx_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:    jmx_exporter
-Version: 0.12.0
-Release: 2%{?dist}
+Version: 0.13.0
+Release: 1%{?dist}
 BuildArch: noarch
 Summary: Prometheus exporter for mBeans scrape and expose.
 License: ASL 2.0


### PR DESCRIPTION
[FEATURE] Added support for jmx attributes of type java.util.Date (#449)
[ENHANCEMENT] Include error message with exception when the agent fails to start. (#399)
[ENHANCEMENT] Allow specifying IPv6 address to bind to (#450)
[ENHANCEMENT] Bump client_java to 0.9.0, including adding /-/healthy (#495)
[BUGFIX] Handle NullPointerException for getAttributes (#444)