### PR TITLE
add mtail package

### DIFF
--- a/mtail/mtail.default
+++ b/mtail/mtail.default
@@ -1,0 +1,2 @@
+# see docs at https://github.com/google/mtail for how to specify logs and write mtail programs
+MTAIL_OPTS="-log_dir /var/log/mtail -progs /etc/prometheus/mtail.d -logs /var/log/messages"

--- a/mtail/mtail.service
+++ b/mtail/mtail.service
@@ -8,10 +8,6 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/mtail
 User=root
-LimitAS=infinity
-LimitRSS=infinity
-LimitCORE=infinity
-LimitNOFILE=65535
 ExecStart=/usr/bin/mtail $MTAIL_OPTS
 Restart=on-failure
 RestartSec=5s

--- a/mtail/mtail.service
+++ b/mtail/mtail.service
@@ -1,0 +1,20 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Extract metrics from application logs
+Documentation=https://github.com/google/mtail
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/mtail
+User=root
+LimitAS=infinity
+LimitRSS=infinity
+LimitCORE=infinity
+LimitNOFILE=65535
+ExecStart=/usr/bin/mtail $MTAIL_OPTS
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/mtail/mtail.spec
+++ b/mtail/mtail.spec
@@ -1,0 +1,50 @@
+%define debug_package %{nil}
+%define pkg_version 3.0.0-rc36
+%define version 3.0.0rc36
+
+Name:    mtail
+Version: %{version}
+Release: 1%{?dist}
+Summary: Extract metrics from application logs
+License: ASL 2.0
+URL:     https://github.com/google/%{name}
+
+Source0: https://github.com/google/%{name}/releases/download/v%{pkg_version}/%{name}_v%{pkg_version}_linux_amd64
+Source1: %{name}.service
+Source2: %{name}.default
+
+%{?systemd_requires}
+Requires(pre): shadow-utils
+
+%description
+
+Extract metrics from application logs to be exported into a timeseries database or timeseries calculator for alerting and dashboarding.
+
+%prep
+
+%build
+/bin/true
+
+%install
+install -D -m 755 %{SOURCE0} %{buildroot}%{_bindir}/%{name}
+install -D -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+install -D -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/default/%{name}
+mkdir -p %{buildroot}%{_sysconfdir}/prometheus/%{name}.d
+mkdir -p %{buildroot}%{_localstatedir}/log/%{name}
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun %{name}.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%dir %{_sysconfdir}/prometheus/%{name}.d
+%dir %{_localstatedir}/log/%{name}


### PR DESCRIPTION
Some quirks with mtail:

- I specify '-logs /var/log/messages' in the defaults file, so it will at least start, but people will really want to configure that specifically for their needs;  this exposes just a count of lines in /var/log/messages, which seems innocuous to me.

Should I leave it so the service won't even start without editing the defaults?

I define bin_version as '3.0.0-rc36' (which matches the binary) and the package version as '3.0.0rc36', since you can't have a dash in there - not sure there's a clever way to avoid having to have both defined.