### PR TITLE
ssl_exporter upstream release - 2.1.0

### DIFF
--- a/ssl_exporter/ssl_exporter.spec
+++ b/ssl_exporter/ssl_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:       ssl_exporter
-Version:    2.0.0
-Release:    3%{?dist}
+Version:    2.1.0
+Release:    1%{?dist}
 Summary:    Prometheus exporter for SSL certificates.
 License:    ASL 2.0
 URL:        https://github.com/ribbybibby/ssl_exporter


### PR DESCRIPTION
Bump to 2.1.0
---
c0f4183 release 2.1.0
17aa4e2 Add metrics for certificates in the verified chains (#48)
ddedd5f Add more information to error logs (#49)
ac9bc31 add a file name extension to the generated binary when the host (e.g. windows) requires it (#47)
b4b8471 build windows release (#43)