### PR TITLE
Update FRR exporter to 0.2.9

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -183,7 +183,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.2.8
+        version: 0.2.9
         license: MIT
         user: frr
         group: frr

--- a/templating.yaml
+++ b/templating.yaml
@@ -187,7 +187,6 @@ packages:
         license: MIT
         user: frr
         group: frr
-        release: 2
         URL: https://github.com/tynany/frr_exporter
         summary: Prometheus exporter for FRR metrics
         description: Export FRR service metrics to Prometheus.

--- a/templating.yaml
+++ b/templating.yaml
@@ -189,6 +189,5 @@ packages:
         group: frr
         release: 2
         URL: https://github.com/tynany/frr_exporter
-        package: '%{name}_%{version}_linux_x86_64'
         summary: Prometheus exporter for FRR metrics
         description: Export FRR service metrics to Prometheus.


### PR DESCRIPTION
Add support to the frr_bgp_peer_prefixes_received_count_total metric for newer versions of FRR