### PR TITLE
Update ssl_exporter to 2.2.1

### DIFF
--- a/ssl_exporter/ssl_exporter.spec
+++ b/ssl_exporter/ssl_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:       ssl_exporter
-Version:    2.1.0
+Version:    2.1.1
 Release:    1%{?dist}
 Summary:    Prometheus exporter for SSL certificates.
 License:    ASL 2.0


### PR DESCRIPTION
Upstream release:
---

v2.1.1

@ribbybibby ribbybibby released this 7 days ago
Changelog

224fb62 release 2.1.1
b84db80 Fix ssl_verified_cert_not_after typo