### PR TITLE
Update Redis exporter to 1.12.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -58,11 +58,10 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.9.0
-        license: ASL 2.0
-        release: 2
+        version: 1.12.0
+        license: MIT
         summary: Prometheus exporter for Redis server metrics.
-        description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, and 5.x
+        description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x
         package: '%{name}-v%{version}.linux-amd64'
         URL: https://github.com/oliver006/redis_exporter
       dynamic:


### PR DESCRIPTION
Update Redis exporter to 1.12.0 and fix license.