### PR TITLE
Update Blackbox Exporter to 0.18.0

### DIFF
--- a/blackbox_exporter/blackbox_exporter.spec
+++ b/blackbox_exporter/blackbox_exporter.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:    blackbox_exporter
-Version: 0.17.0
-Release: 2%{?dist}
+Version: 0.18.0
+Release: 1%{?dist}
 Summary: Blackbox prober exporter
 License: ASL 2.0
 URL:     https://github.com/prometheus/%{name}


### PR DESCRIPTION
[ENHANCEMENT] Expose probe_dns_duration_seconds metric (#662)
[ENHANCEMENT] Add probe_icmp_reply_hop_limit (#694)
[ENHANCEMENT] prober/tls: adding metric to expose certificate fingerprint info (#678)
[BUGFIX] prober/tls: fix probe_ssl_last_chain_expiry_timestamp_seconds (#681)
[BUGFIX] Fix incorrect content length reporting when using regexes (#674)
[BUGFIX] Fix panic when running ICMPv4 probe with DontFragment (#686)
[BUGFIX] Deal with URLs with literal IPv6 addresses (#645)
[BUGFIX] Change DoT default port to 853 (#655)