### PR TITLE
Update statsd exporter to 0.18.0

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.17.0
+Version: 0.18.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
[ENHANCEMENT] Allow turning off tagging extensions (#325)
[ENHANCEMENT] Add a lifecycle API for configuration reloads and restarts (#329)
This release changes the interface for the github.com/prometheus/statsd_exporter/pkg/line library package to support the new configurability.