### PR TITLE
Update Prometheus to 2.22.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.21.0
+Version: 2.22.0
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
[CHANGE] web: Remove APIv2. #7935
[ENHANCEMENT] React UI: Implement missing TSDB head stats section. #7876
[ENHANCEMENT] UI: Add Collapse all button to targets page. #6957
[ENHANCEMENT] UI: Clarify alert state toggle via checkbox icon. #7936
[ENHANCEMENT] Add rule_group_last_evaluation_samples and prometheus_tsdb_data_replay_duration_seconds metrics. #7737 #7977
[ENHANCEMENT] Gracefully handle unknown WAL record types. #8004
[ENHANCEMENT] Issue a warning for 64 bit systems running 32 bit binaries. #8012
[BUGFIX] Adjust scrape timestamps to align them to the intended schedule, effectively reducing block size. Workaround for a regression in go1.14+. #7976
[BUGFIX] promtool: Ensure alert rules are marked as restored in unit tests. #7661
[BUGFIX] Eureka: Fix service discovery when compiled in 32-bit. #7964
[BUGFIX] Don't do literal regex matching optimisation when case insensitive. #8013
[BUGFIX] Fix classic UI sometimes running queries for instant query when in range query mode. #7984