### PR TITLE
Update FRR exporter to 0.2.10

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -181,7 +181,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.2.9
+        version: 0.2.10
         license: MIT
         user: frr
         group: frr


### PR DESCRIPTION
BGP peers with a state of Idle (Admin) now return a value of 2 for the frr_bgp_peer_state metric.