### PR TITLE
Update OpenStack exporter to 1.2.0

### DIFF
--- a/openstack_exporter/openstack_exporter.spec
+++ b/openstack_exporter/openstack_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    openstack_exporter
-Version: 1.1.0
+Version: 1.2.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for OpenStack metrics
 License: MIT


### PR DESCRIPTION
The following fixes and metrics have been included on this release:

Metrics with L3agents for routers (#129)
Remove loadbalancer metrics from neutron (#128)
Fix gnocchi tests [disabled for now]
Implemented gnocchi exporter with 4 new metrics (#125)
Admin state for ports (#126)
Metrics for each Floating IP (#124)
Add hypervisor_hostname label to Nova server_status metric (#123)
add uuid to agent_state fields (#116)
Add Ironic node state exporter (#113)
Update README.md (#111)
Fix dns metrics for all projects (#109)