### PR TITLE
Update Thanos to 0.16.0

### DIFF
--- a/thanos/thanos-compact.default
+++ b/thanos/thanos-compact.default
@@ -1,1 +1,1 @@
-THANOS_COMPACT_OPTS='--data-dir=/var/lib/thanos/compact --http-address=0.0.0.0:19191'
+THANOS_COMPACT_OPTS='--data-dir=/var/lib/thanos/compact --http-address=0.0.0.0:10912'

--- a/thanos/thanos-query.default
+++ b/thanos/thanos-query.default
@@ -1,1 +1,1 @@
-THANOS_QUERY_OPTS='--http-address=0.0.0.0:19192 --grpc-address=0.0.0.0:19092 --store=localhost:10901'
+THANOS_QUERY_OPTS='--http-address=0.0.0.0:10904 --grpc-address=0.0.0.0:10903 --store=localhost:10901'

--- a/thanos/thanos-rule.default
+++ b/thanos/thanos-rule.default
@@ -1,1 +1,1 @@
-THANOS_RULE_OPTS='--data-dir=/var/lib/thanos/rule --http-address=0.0.0.0:19902 --grpc-address=0.0.0.0:19901 --rule-file=/etc/prometheus/thanos_alerts.yml --query=localhost:19192'
+THANOS_RULE_OPTS='--data-dir=/var/lib/thanos/rule --http-address=0.0.0.0:10911 --grpc-address=0.0.0.0:10911 --rule-file=/etc/prometheus/thanos_alerts.yml --query=localhost:10904'

--- a/thanos/thanos-store.default
+++ b/thanos/thanos-store.default
@@ -1,1 +1,1 @@
-THANOS_STORE_OPTS='--data-dir=/var/lib/thanos/store --http-address=0.0.0.0:19191 --grpc-address=0.0.0.0:19090'
+THANOS_STORE_OPTS='--data-dir=/var/lib/thanos/store --http-address=0.0.0.0:10906 --grpc-address=0.0.0.0:10905'

--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.15.0
-Release: 3%{?dist}
+Version: 0.16.0
+Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0
 URL:     https://thanos.io


### PR DESCRIPTION
Highlights:

New Thanos component, Query Frontend has more options and supports shared cache (currently: Memcached).
Added debug mode in Thanos UI that allows to filter Stores to query from by their IPs from Store page (!). This helps enormously in e.g debugging the slowest store etc. All raw Thanos API allows passing
storeMatch[] arguments with __address__ matchers.
Improved debuggability on all Thanos components by exposing off-CPU profiles thanks to fgprof endpoint.
Significantly improved sidecar latency and CPU usage for metrics fetches.
Fixed
#3234 UI: Fix assets not loading when --web.prefix-header is used.
#3184 Compactor: Fixed support for web.external-prefix for Compactor UI.
Added
#3114 Query Frontend: Added support for Memacached cache.
breaking Renamed flag log_queries_longer_than to log-queries-longer-than.
#3166 UIs: Added UI for passing a storeMatch[] parameter to queries.
#3181 Logging: Added debug level logging for responses between 300-399
#3133 Query: Allowed passing a storeMatch[] to Labels APIs; Time range metadata based store filtering is supported on Labels APIs.
#3146 Sidecar: Significantly improved sidecar latency (reduced ~2x). Added thanos_sidecar_prometheus_store_received_frames histogram metric.
#3147 Querier: Added query.metadata.default-time-range flag to specify the default metadata time range duration for retrieving labels through Labels and Series API when the range parameters are not specified. The zero value means range covers the time since the beginning.
#3207 Query Frontend: Added cache-compression-type flag to use compression in the query frontend cache.
#3122 *: All Thanos components have now /debug/fgprof endpoint on HTTP port allowing to get off-CPU profiles as well.
#3109 Query Frontend: Added support for Cache-Control HTTP response header which controls caching behaviour. So far no-store value is supported and it makes the response skip cache.
#3092 Tools: Added tools bucket cleanup CLI tool that deletes all blocks marked to be deleted.
Changed
#3136 Sidecar: breaking Added metric thanos_sidecar_reloader_config_apply_operations_total and rename metric thanos_sidecar_reloader_config_apply_errors_total to thanos_sidecar_reloader_config_apply_operations_failed_total.
#3154 Querier: breaking Added metric thanos_query_gate_queries_max. Remove metric thanos_query_concurrent_selects_gate_queries_in_flight.
#3154 Store: breaking Renamed metric thanos_bucket_store_queries_concurrent_max to thanos_bucket_store_series_gate_queries_max.
#3179 Store: context.Canceled will not increase thanos_objstore_bucket_operation_failures_total.
#3136 Sidecar: Improved detection of directory changes for Prometheus config.
breaking Added metric thanos_sidecar_reloader_config_apply_operations_total and rename metric thanos_sidecar_reloader_config_apply_errors_total to thanos_sidecar_reloader_config_apply_operations_failed_total.
#3022 *: Thanos images are now build with Go 1.15.
#3205 *: Updated TSDB to ~2.21