### PR TITLE
Update prometheus to 2.22.1

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.22.0
+Version: 2.22.1
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
[BUGFIX] Fix potential "mmap: invalid argument" errors in loading the head chunks, after an unclean shutdown, by performing read repairs. #8061
[BUGFIX] Fix serving metrics and API when reloading scrape config. #8104
[BUGFIX] Fix head chunk size calculation for size based retention. #8139