### PR TITLE
Update Thanos to 0.17.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.16.0
-Release: 2%{?dist}
+Version: 0.17.0
+Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0
 URL:     https://thanos.io


### PR DESCRIPTION
Highlights
BlockViewer now allows downloading meta.json of a block directly from Compact/Web UI.
thanos query-frontend now supports query splitting and retries for label names and label values APIs.
thanos tools bucket replicate can now copy particular block s by ID or time range.
thanos query is now using dynamic lookback delta when downsampled data is used by default.
More katacoda tutorials!
Compactor is aware of 64GB index size limits and automatically avoids compacting blocks to a bigger size than this. Admin can
also manually exclude block from further compaction by uploading no-compact-mark.json file to bucket block directory.
Added thanos tools bucket mark for marking blocks with no compact or delayed deletion marker.
When enabled ( --store.enable-index-header-lazy-reader flag), Store Gateway will mmap only those blocks caches that are needed for the queries. This option will be set to default in next release.
⚠️ Breaking change ⚠️ Dozens of metrics were renamed for consistency. (Particularly thanos_querier_... to thanos_query_... and thanos_compactor_... to thanos_compact_...
Added
#3259 Thanos BlockViewer: Added a button in the blockviewer that allows users to download the metadata of a block.
#3261 Thanos Store: Use segment files specified in meta.json file, if present. If not present, Store does the LIST operation as before.
#3276 Query Frontend: Support query splitting and retry for label names, label values and series requests.
#3315 Query Frontend: Support results caching for label names, label values and series requests.
#3346 Ruler UI: Fix a bug preventing the /rules endpoint from loading.
#3115 compact: now deletes partially uploaded and blocks with deletion marks concurrently. It does that at the beginning and then every --compact.cleanup-interval time period. By default it is 5 minutes.
#3312 s3: add list_objects_version config option for compatibility.
#3356 Query Frontend: Add a flag to disable step alignment middleware for query range.
#3378 Ruler: added the ability to send queries via the HTTP method POST. Helps when alerting/recording rules are extra long because it encodes the actual parameters inside of the body instead of the URI. Thanos Ruler now uses POST by default unless --query.http-method is set GET.
#3381 Querier UI: Add ability to enable or disable metric autocomplete functionality.
#2979 Replicator: Add the ability to replicate blocks within a time frame by passing --min-time and --max-time
#3398 Query Frontend: Add default config for query frontend memcached config.
#3277 Thanos Query: Introduce dynamic lookback interval. This allows queries with large step to make use of downsampled data.
#3409 Compactor: Added support for no-compact-mark.json which excludes the block from compaction.
#3245 Query Frontend: Add query-frontend.org-id-header flag to specify HTTP header(s) to populate slow query log (e.g. X-Grafana-User).
#3431 Store: Added experimental support to lazy load index-headers at query time. When enabled via --store.enable-index-header-lazy-reader flag, the store-gateway will load into memory an index-header only once it's required at query time. Index-header will be automatically released after --store.index-header-lazy-reader-idle-timeout of inactivity.
This, generally, reduces baseline memory usage of store when inactive, as well as a total number of mapped files (which is limited to 64k in some systems.
#3415 Tools: Added thanos tools bucket mark command that allows to mark given block for deletion or for no-compact
Fixed
#3257 Ruler: Prevent Ruler from crashing when using default DNS to lookup hosts that results in "No such hosts" errors.
#3331 Disable Azure blob exception logging
#3341 Disable Azure blob syslog exception logging
#3414 Set CORS for Query Frontend
Changed
#3452 Store: Index cache posting compression is now enabled by default. Removed experimental.enable-index-cache-postings-compression flag.
#3410 Compactor: Changed metric thanos_compactor_blocks_marked_for_deletion_total to thanos_compactor_blocks_marked_total with marker label.
Compactor will now automatically disable compaction for blocks with large index that would output blocks after compaction larger than specified value (by default: 64GB). This automatically
handles the Promethus format limit.
#2906 Tools: Refactor Bucket replicate execution. Removed all thanos_replicate_origin_.* metrics.
thanos_replicate_origin_meta_loads_total can be replaced by blocks_meta_synced{state="loaded"}.
thanos_replicate_origin_partial_meta_reads_total can be replaced by blocks_meta_synced{state="failed"}.
#3309 Compact: breaking ⚠️ Rename metrics to match naming convention. This includes metrics starting with thanos_compactor to thanos_compact, thanos_querier to thanos_query and thanos_ruler to thanos_rule.