### PR TITLE
Update Thanos to 0.17.1

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.17.0
+Version: 0.17.1
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Fixed
#3480 Query-frontend: Fixed regression.
Changed
#3498 Enabled debug.SetPanicOnFault(true) which allow us to recover on queries causing SEG FAULTs (e.g unmmaped memory access).