### PR TITLE
Update mongodb exporter to 0.20.1

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -209,7 +209,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.11.2
+        version: 0.20.1
         license: ASL 2.0
         URL: https://github.com/percona/mongodb_exporter
         package: "%{name}-%{version}.linux-amd64"


### PR DESCRIPTION
PMM-6811: Secondary lag reported as 136 years