### PR TITLE
memcached_exporter upstream release: 0.8.0

### DIFF
--- a/memcached_exporter/memcached_exporter.spec
+++ b/memcached_exporter/memcached_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    memcached_exporter
-Version: 0.7.0
+Version: 0.8.0
 Release: 1%{?dist}
 Summary: Prometheus memcached exporter.
 License: ASL 2.0


### PR DESCRIPTION
    [FEATURE] Support MySQL's InnoDB memcached plugin (by handling their multi-word stats settings values)
    [FEATURE] Make exporter logic available as standalone library package #97
    [ENHANCEMENT] Add --version flag and version metric #99
    [ENHANCEMENT] Update prometheus client library