### PR TITLE
Upstream release - Thanos 0.17.2

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:	 thanos
-Version: 0.17.1
+Version: 0.17.2
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
---
    #3532 compact: do not cleanup blocks on boot. Reverts the behavior change introduced in #3115 as in some very bad cases the boot of Thanos Compact took a very long time since there were a lot of blocks-to-be-cleaned.
    #3520 Fix index out of bound bug when comparing ZLabelSets.