### PR TITLE
ssl_exporter - upstream release 2.2.0

### DIFF
--- a/ssl_exporter/ssl_exporter.spec
+++ b/ssl_exporter/ssl_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:       ssl_exporter
-Version:    2.1.1
+Version:    2.2.0
 Release:    1%{?dist}
 Summary:    Prometheus exporter for SSL certificates.
 License:    ASL 2.0


### PR DESCRIPTION
This release includes a number of new features:

    OCSP stapling metrics
    Prober for certificates in Kubernetes secrets
    Prober for certificates in local files
    Configurable timeout for modules

Please note that the ssl_tls_connect_success metric has been renamed to ssl_probe_success.

# Changelog

5d3ac12 release 2.2.0
44d8713 Add test for TLS version metric
8cde56c Fix examples in the README
fdda9c3 Add prober column to metrics table
d92d7be Add file prober to example config
ca7aa1f Fix golint errors
13a03b1 Move tests to prober package
67539b6 Use same results check for file + kube probes
f4782e3 Make the description in the README more succinct
63dcb9a Add kubernetes prober
0506638 Add file prober
c74c0de Refactor prober function and metrics collection
e05745b Export OCSP stapling metrics (#54)
896b59b Update deps && go 1.15
119d3cd Add a configurable timeout to the module configuration (#55)