### PR TITLE
Update Redis exporter to 1.14.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -58,7 +58,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.13.1
+        version: 1.14.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x


### PR DESCRIPTION
PR #462 - allow configuring whether the port is included in the client's details (by default it is not)