### PR TITLE
Update OpenStack exporter to 1.3.0

### DIFF
--- a/openstack_exporter/openstack_exporter.spec
+++ b/openstack_exporter/openstack_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    openstack_exporter
-Version: 1.2.0
+Version: 1.3.0
 Release: 1%{?dist}
 Summary: Prometheus exporter for OpenStack metrics
 License: MIT


### PR DESCRIPTION
8bf713c fixes #122 (#150)
8e56979 Bind a exporter to only needed tcp version (#147)
3f31226 Add limits values for instances (#149)
9a9210d Add volume_status_counter metric (#143)
12e1802 Add support for multiple clouds (#141)
4fc2447 add metric free_disk_bytes for hypervisors (#145)
486e009 Add support for proxy (#140)
1fede2f Resolve #135 (#138)
ce689fe Add option to disable slow metrics. (#134)
a8ccd28 Add project_info metrics (#131)