### PR TITLE
Update Redis Exporter to 1.15.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -58,7 +58,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.14.0
+        version: 1.15.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x


### PR DESCRIPTION
PR #457 Support for memory usage aggregation by key groups (thanks @rmak-cpi )
PR #466 Bump prometheus/client_golang library from 1.8.0 to 1.9.0