### PR TITLE
statsd_exporter upstream release, 0.19.0

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.18.0
+Version: 0.19.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
Upstream release:

0.19.0 / 2021-01-22

[CHANGE] [library] Require explicit Registerer (#347)
[ENHANCEMENT] Add /-/healthy and /-/ready endpoints (#339)
[BUGFIX] Do not open network ports when only checking config (#357)