### PR TITLE
mtail upstream release - 3.0.0-rc43

### DIFF
--- a/mtail/mtail.spec
+++ b/mtail/mtail.spec
@@ -9,7 +9,7 @@ Summary: Extract metrics from application logs
 License: ASL 2.0
 URL:     https://github.com/google/%{name}
 
-Source0: https://github.com/google/%{name}/releases/download/v%{pkg_version}/%{name}_v%{pkg_version}_linux_amd64
+Source0: https://github.com/google/%{name}/releases/download/v%{pkg_version}/%{name}_%{pkg_version}_Linux_arm64.tar.gz
 Source1: %{name}.service
 Source2: %{name}.default
 
@@ -21,6 +21,7 @@ Requires(pre): shadow-utils
 Extract metrics from application logs to be exported into a timeseries database or timeseries calculator for alerting and dashboarding.
 
 %prep
+%setup -q -D -c %{name}
 
 %build
 /bin/true

--- a/mtail/mtail.spec
+++ b/mtail/mtail.spec
@@ -1,6 +1,6 @@
 %define debug_package %{nil}
-%define pkg_version 3.0.0-rc38
-%define version 3.0.0rc38
+%define pkg_version 3.0.0-rc43
+%define version 3.0.0rc43
 
 Name:    mtail
 Version: %{version}


### PR DESCRIPTION
Upstream releases

v3.0.0-rc43

Changelog
cc69d15 Switch the store RWMutex to a pair of categorical mutices.
9e0c20e Benchmark adds to the metrics store.
77cb9d6 No need for IMPORTS definition with go mod download.
c277f15 Use go mod download to fetch deps instead of doing it manually.
8262f12 Remove crossbuild target now we use goreleaser.
73d14bf Don't include Merge commits in changelog.
b2de91a Remove unused parameter from TestStartServer.
c9a2351 Reenable the unix socket listen test.

v3.0.0-rc42

Changelog
7609963 Add a new TODO.
1aac176 Avoid faffing with text processing in shell for benchstat.
4462ae8 Count when logstream fds are closed and use that to fix test flake.
9894852 Do benchstat in text not HTML.
8a9021a Fix order of arguments in TestMakeServer.
25ca804 Fix typo in autoreview action.
16cae74 Fix typo in name of subtests.
c4f529b Fix up benchmark text emission.
cff7c9e Merge pull request #445 from jaqx0r/cleanup
57e2843 Merge pull request #446 from jaqx0r/cleanup
47ae373 Merge pull request #447 from jaqx0r/cleanup
465f0c9 Merge pull request #449 from jaqx0r/cleanup
8aa1874 Move a debug log message to level 2 verbosity.
cd77e2d Remove a completed TODO.
8963571 Remove branch-cleanup.yml.
b01d4fc Rename TestChdir to just testutil.Chdir to avoid stutter.
6fd7fba Rename TestSetFlag and register a cleanup function.
333e465 Reorder post-Read conditions to deal with bytes before error.
55ceb73 Replace path.Join with filepath.Join.
08bad80 Shut down other blocked channel ops with context Done.
1e1c800 TestServer doesn't return a cleanup function, it is used during tests to stop mtail.
fc47202 Turn the CI badge into a link to the workflow results.
c9c12b5 Update a TODO after attempting to resolve it.
1d6b4e0 Use a barrier to ensure we awaken at the right moment to fix a flake.
e902b52 Use same style for branch-cleanup as for other actions.
3a886cb Use t.Cleanup in testutil.TestChdir instead of returning a deferrable.
b0e79f7 Use t.Cleanup in testutil.TestTempDir.
555568a Use the new log_closes_total counter to also deflake the deletion test.
aafc4be Wrap benchmark in details tag.
ae4409a quote bits in benchmark comment.

v3.0.0-rc41

Changelog
fbaf2e0 Merge pull request #443 from google/jaqx0r-patch-1
f2d5e21 Remove cache and deps steps from release.