### PR TITLE
Update Domain Exporter to 1.9.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -193,7 +193,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 1.8.0
+        version: 1.9.0
         license: MIT
         URL: https://github.com/caarlos0/domain_exporter
         package: '%{name}_linux_amd64'


### PR DESCRIPTION
41a2381 fix: lint issues
824a51e feat: latest deps
f86c47f feat: .im tld date format (#82)
a896661 chore(deps): bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#81)
f6947b1 chore(deps): bump github.com/prometheus/client_golang (#80)
55d4f7e chore(deps): bump github.com/prometheus/client_golang from 1.7.1 to 1.8.0
86217ff chore: lint issues
73cbe54 chore(deps): bump github.com/prometheus/common from 0.13.0 to 0.15.0 (#79)