### PR TITLE
Update Redis Exporter to 1.16.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -58,7 +58,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.15.1
+        version: 1.16.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x


### PR DESCRIPTION
Release notes: https://github.com/oliver006/redis_exporter/releases/tag/v1.16.0