### PR TITLE
statsd_exporter upstream release, 0.20.0

### DIFF
--- a/statsd_exporter/statsd_exporter.spec
+++ b/statsd_exporter/statsd_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    statsd_exporter
-Version: 0.19.0
+Version: 0.20.0
 Release: 1%{?dist}
 Summary: Prometheus StatsD exporter.
 License: ASL 2.0


### PR DESCRIPTION
Upstream releases 0.19.1 and 0.20.0:
---
This is a double-release because I had forgotten to hit "publish" on 0.19.1.

A big thank you goes to @glightfoot for providing both changes.

/MR
0.19.1 / 2021-01-29
[BUGFIX] Don't return empty responses to lifecycle api requests (#360)

0.20.0 / 2021-02-05

[ENHANCEMENT] Support full defaults for summaries and histograms (#361)
This completes support for summary_options and histogram_options.
Change the legacy configuration attributes throughout the mapping configuration as follows:

quantiles: … to summary_options: { quantiles: … }
buckets: … to histogram_options: { buckets: … }
timer_type to observer_type.
Support for the deprecated attributes will be removed in a future release.