### PR TITLE
Update Node Exporter to 1.1.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -29,9 +29,8 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 1.0.1
+        version: 1.1.0
         license: ASL 2.0
-        release: 2
         URL: https://github.com/prometheus/node_exporter
         summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
         description: |


### PR DESCRIPTION
Release notes: https://github.com/prometheus/node_exporter/releases/tag/v1.1.0