### PR TITLE
Update FRR exporter to 0.2.11

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -178,7 +178,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.2.10
+        version: 0.2.11
         license: MIT
         user: frr
         group: frr


### PR DESCRIPTION
Release notes: https://github.com/tynany/frr_exporter/releases/tag/v0.2.11