### PR TITLE
mtail upstream release - 3.0.0rc44

### DIFF
--- a/mtail/mtail.spec
+++ b/mtail/mtail.spec
@@ -1,6 +1,6 @@
 %define debug_package %{nil}
-%define pkg_version 3.0.0-rc43
-%define version 3.0.0rc43
+%define pkg_version 3.0.0-rc44
+%define version 3.0.0rc44
 
 Name:    mtail
 Version: %{version}


### PR DESCRIPTION
Upstream release:

v3.0.0-rc44

Changelog
499147e Downgrade the timed out message from pipestream as it's expected.
641107c Bump go.opencensus.io from 0.22.5 to 0.22.6
ad985d8 SIGHUP reload: fix empty path check
7339959 Robustify TestServer.GetProgramMetric.
dc34c39 Simplify test data by creating a MetricSlice.
22f0dc6 Use the Range method in benchmark to ensure iteration over all metrics.
7138405 Set benchmark timeout to 120m.
c64d3e1 Make the Store's mutexes internal.
7efe686 Move the FindMetricOrNil method from reader to Store.
c3f06fb Convert prometheus export to use store.Range.
a71fa5f Emit Metric.Source in the JSON output.
0c74e45 Add a Range method to Store.
ab3cbf2 Move the metrics store dump to the main function.
94f1600 Update some comments in examples.
dacf36e Remove a completed TODO.
eeedb48 Move ip-addr example to the vm_integration_test.
72c8019 Move stringy example to the vm_integration_test.
70f7145 Move the metric-as-rvalue example to the vm_integration_test.
b02768f Move the match-expression example to the vm_integration_test.
0cb1c25 Move the typed-comparison example to the vm_integration_test.
318e277 Move the strcat example to the vm_integration_test.
b18a8bb Move the logical example to the vm_integration_test.
0415c40 Inline an example in the doc.
b12d352 Move the filename example to the vm_integration_test.
5a5d896 Move the types example to the vm_integration_test.
419a20b Move the otherwise example to the vm_integration_test.
a4db9a3 Move the else example to the vm_integration_test.
80917d0 Move the decorator example to the vm_integration_test.
9c4cbec Move the add_assign_float example to the vm integration test.
79d001d Activate stale issue/pr handler.