### PR TITLE
Update SNMP exporter to 0.20.0

### DIFF
--- a/snmp_exporter/snmp_exporter.spec
+++ b/snmp_exporter/snmp_exporter.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:    snmp_exporter
-Version: 0.19.0
+Version: 0.20.0
 Release: 1%{?dist}
 Summary: Prometheus SNMP exporter.
 License: ASL 2.0


### PR DESCRIPTION
Release notes: https://github.com/prometheus/snmp_exporter/releases/tag/v0.20.0