### PR TITLE
Update Prometheus to 2.25.1

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.25.0
+Version: 2.25.1
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
    [BUGFIX] Fix a crash in promtool when a subquery with default resolution is used. #8569
    [BUGFIX] Fix a bug that could return duplicate datapoints in queries. #8591
    [BUGFIX] Fix crashes with arm64 when compiled with go1.16. #8593