### PR TITLE
Update Prometheus to 2.25.2

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.25.1
+Version: 2.25.2
 Release: 1%{?dist}
 Summary: The Prometheus 2.x monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
```
[BUGFIX] Fix the ingestion of scrapes when the wall clock changes, e.g. on suspend. #8601
```