### PR TITLE
Set open_file_limit  for blackbox_exporter

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -96,6 +96,7 @@ packages:
       static:
         <<: *default_static_context
         version: 0.19.0
+        release: 1
         license: ASL 2.0
         URL: https://github.com/prometheus/blackbox_exporter
         service_opts:
@@ -107,6 +108,7 @@ packages:
             from_tarball: true
             mode: 640
             group: '%{group}'
+        open_file_limit: 16384     
         summary: Blackbox prober exporter
         description: |
           The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS,

--- a/templating.yaml
+++ b/templating.yaml
@@ -108,7 +108,7 @@ packages:
             from_tarball: true
             mode: 640
             group: '%{group}'
-        open_file_limit: 16384     
+        open_file_limit: 16384
         summary: Blackbox prober exporter
         description: |
           The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS,

--- a/templating.yaml
+++ b/templating.yaml
@@ -96,7 +96,7 @@ packages:
       static:
         <<: *default_static_context
         version: 0.19.0
-        release: 1
+        release: 2
         license: ASL 2.0
         URL: https://github.com/prometheus/blackbox_exporter
         service_opts:


### PR DESCRIPTION
I was bitten by 'too many open files' with blackbox_exporter (I was having a timeout issue and connections pile-up when that happens).

Is 16k enough?