### PR TITLE
Update Prometheus to 2.28.0

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:		 prometheus2
-Version: 2.27.1
+Version: 2.28.0
 Release: 1%{?dist}
 Summary: The Prometheus monitoring system and time series database.
 License: ASL 2.0


### PR DESCRIPTION
Release notes: https://github.com/prometheus/prometheus/releases/tag/v2.28.0