### PR TITLE
snmp_exporter: set open_file_limit to 16k

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -121,7 +121,7 @@ packages:
       static:
         <<: *default_static_context
         version: 0.20.0
-        release: 3
+        release: 4
         license: ASL 2.0
         URL: https://github.com/prometheus/snmp_exporter
         service_opts:
@@ -132,6 +132,7 @@ packages:
             from_tarball: true
             mode: 640
             group: '%{group}'
+        open_file_limit: 16384
         summary: Prometheus SNMP exporter.
         description: |
           This is an exporter that exposes information gathered from SNMP for use by the


### PR DESCRIPTION
For large SNMP installations (like mine), 1,024 is a bit low.

Signed-off-by: Ben Ritcey <ben+github@ritcey.com>