### PR TITLE
add ExecReload to unit

### DIFF
--- a/prometheus2/prometheus2.spec
+++ b/prometheus2/prometheus2.spec
@@ -2,7 +2,7 @@
 
 Name:		 prometheus2
 Version: 2.28.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Prometheus monitoring system and time series database.
 License: ASL 2.0
 URL:     https://prometheus.io

--- a/templates/unit.tpl
+++ b/templates/unit.tpl
@@ -12,6 +12,7 @@ After=network.target
 EnvironmentFile=-/etc/default/{{name}}
 User={{user}}
 ExecStart=/usr/bin/{{name}} ${{name|upper}}_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5s
 {% if open_file_limit is defined -%}

--- a/templating.yaml
+++ b/templating.yaml
@@ -50,6 +50,7 @@ packages:
       static:
         <<: *default_static_context
         version: 0.22.2
+        release: 2
         license: ASL 2.0
         URL: https://github.com/prometheus/alertmanager
         service_opts:


### PR DESCRIPTION
The templated systemd unit file doesn't have a Reload action - 'kill -HUP $MAINPID' looks to have been fairly standard.

Is this fine to have by default or should it be something explicitly enabled via a switch in templating.yml?