### PR TITLE
Add artifactory_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ sachet \
 jiralert \
 ebpf_exporter \
 karma \
-bareos_exporter
+bareos_exporter \
+artifactory_exporter
 
 .PHONY: $(MANUAL) $(AUTO_GENERATED)
 

--- a/templating.yaml
+++ b/templating.yaml
@@ -729,3 +729,17 @@ packages:
         summary: Prometheus exporter for BareOS data recovery system
         description: |
           Prometheus exporter for BareOS data recovery system.
+  artifactory_exporter:
+    build_steps:
+      <<: *default_build_steps
+    context:
+      <<: *default_context
+      static:
+        <<: *default_static_context
+        version: 1.9.1
+        license: ASL 2.0
+        URL: https://github.com/peimanja/artifactory_exporter
+        package: '%{name}-v%{version}-linux-amd64'
+        tarball_has_subdirectory: false
+        summary: Prometheus exporter for JFrog Artifactory stats.
+        description: Collects metrics about an Artifactory system

--- a/templating.yaml
+++ b/templating.yaml
@@ -741,5 +741,8 @@ packages:
         URL: https://github.com/peimanja/artifactory_exporter
         package: '%{name}-v%{version}-linux-amd64'
         tarball_has_subdirectory: false
+        environment:
+          ARTI_USERNAME: username
+          ARTI_PASSWORD: password
         summary: Prometheus exporter for JFrog Artifactory stats.
         description: Collects metrics about an Artifactory system


### PR DESCRIPTION
This adds [artifactory_exporter](https://github.com/peimanja/artifactory_exporter). This was tested on an EL7-compatible system running 6.23.23.

`ARTI_USERNAME` and `ARTI_PASSWORD` needs to be set manually in `/etc/default/artifactory_exporter`. I wasn't sure if it was appropriate to define them via `environment` but leave them blank or not.