### PR TITLE
Add pgbouncer_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ pushgateway \
 mysqld_exporter \
 elasticsearch_exporter \
 postgres_exporter \
+pgbouncer_exporter \
 redis_exporter \
 haproxy_exporter \
 kafka_exporter \

--- a/templating.yaml
+++ b/templating.yaml
@@ -175,6 +175,20 @@ packages:
         summary: Prometheus exporter for PostgreSQL server metrics
         description: |
           Prometheus exporter for PostgreSQL server metrics.
+  pgbouncer_exporter:
+    build_steps:
+      <<: *default_build_steps
+    context:
+      <<: *default_context
+      static:
+        <<: *default_static_context
+        version: 0.4.0
+        license: MIT
+        URL: https://github.com/prometheus-community/pgbouncer_exporter
+        user: postgres
+        group: postgres
+        summary: Prometheus exporter for PgBouncer.
+        description: Prometheus exporter for PgBouncer. Exports metrics at 9127/metrics
   elasticsearch_exporter:
     build_steps:
       <<: *default_build_steps


### PR DESCRIPTION
Works out of the box with the default pgbouncer configuration. Tested with 1.15.0 on EL7-compatible system.