### PR TITLE
Update Thanos Query defaults

### DIFF
--- a/thanos/thanos-query.default
+++ b/thanos/thanos-query.default
@@ -1,1 +1,1 @@
-THANOS_QUERY_OPTS='--http-address=0.0.0.0:10904 --grpc-address=0.0.0.0:10903 --store=localhost:10901'
+THANOS_QUERY_OPTS='--http-address=0.0.0.0:10904 --grpc-address=0.0.0.0:10903 --endpoint=localhost:10901'

--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -2,7 +2,7 @@
 
 Name:	 thanos
 Version: 0.24.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0
 URL:     https://thanos.io


### PR DESCRIPTION
Update Thanos Query defaults as store parameter has been deprecated and replaced by endpoint parameter