### PR TITLE
add a build target for CentOS Stream 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           - auto
           - manual
         version:
+          - 9
           - 8
           - 7
     runs-on: ubuntu-20.04
@@ -55,6 +56,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - 9
           - 8
           - 7
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(addprefix build9-,$(MANUAL)):
 		-v ${PWD}/_dist9:/rpmbuild/RPMS/x86_64 \
 		-v ${PWD}/_dist9:/rpmbuild/RPMS/noarch \
 		-v ${PWD}/_cache_dnf:/var/cache/dnf \
-		ghcr.io/lest/centos-rpm-builder:stream9 \
+		ghcr.io/lest/centos-rpm-builder:oracle9 \
 		build-spec SOURCES/${PACKAGE}.spec
 	# Test the install
 	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9      
@@ -89,7 +89,7 @@ $(addprefix build9-,$(MANUAL)):
 	docker run --privileged ${DOCKER_FLAGS} \
 		-v ${PWD}/_dist9:/var/tmp/ \
 		-v ${PWD}/_cache_dnf:/var/cache/dnf \
-		ghcr.io/lest/centos-rpm-builder:stream9 \
+		ghcr.io/lest/centos-rpm-builder:oracle9 \
 		/bin/bash -c '/usr/bin/dnf install --verbose -y /var/tmp/${PACKAGE}*.rpm'
 
 $(addprefix build8-,$(MANUAL)):
@@ -148,7 +148,7 @@ $(addprefix build9-,$(AUTO_GENERATED)):
 		-v ${PWD}/_dist9:/rpmbuild/RPMS/x86_64 \
 		-v ${PWD}/_dist9:/rpmbuild/RPMS/noarch \
 		-v ${PWD}/_cache_dnf:/var/cache/dnf \
-		ghcr.io/lest/centos-rpm-builder:stream9 \
+		ghcr.io/lest/centos-rpm-builder:oracle9 \
 		build-spec SOURCES/autogen_${PACKAGE}.spec
 	# Test the install
 	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9      
@@ -156,7 +156,7 @@ $(addprefix build9-,$(AUTO_GENERATED)):
 	docker run --privileged ${DOCKER_FLAGS} \
 		-v ${PWD}/_dist9:/var/tmp/ \
 		-v ${PWD}/_cache_dnf:/var/cache/dnf \
-		ghcr.io/lest/centos-rpm-builder:stream9 \
+		ghcr.io/lest/centos-rpm-builder:oracle9 \
 		/bin/bash -c '/usr/bin/dnf install --verbose -y /var/tmp/${PACKAGE}*.rpm'
 
 sign9:
@@ -166,7 +166,7 @@ sign9:
 		-v ${PWD}/RPM-GPG-KEY-prometheus-rpm:/rpmbuild/RPM-GPG-KEY-prometheus-rpm \
 		-v ${PWD}/secret.asc:/rpmbuild/secret.asc \
 		-v ${PWD}/.passphrase:/rpmbuild/.passphrase \
-		ghcr.io/lest/centos-rpm-builder:stream9 \
+		ghcr.io/lest/centos-rpm-builder:oracle9 \
 		bin/sign
 
 $(addprefix build8-,$(AUTO_GENERATED)):

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,29 @@ all: auto manual
 manual: $(MANUAL)
 auto: $(AUTO_GENERATED)
 
+manual9: $(addprefix build9-,$(MANUAL))
 manual8: $(addprefix build8-,$(MANUAL))
 manual7: $(addprefix build7-,$(MANUAL))
+
+$(addprefix build9-,$(MANUAL)):
+	$(eval PACKAGE=$(subst build9-,,$@))
+	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9 
+	[ -d ${PWD}/_cache_dnf ] || mkdir ${PWD}/_cache_dnf 
+	docker run ${DOCKER_FLAGS} \
+		-v ${PWD}/${PACKAGE}:/rpmbuild/SOURCES \
+		-v ${PWD}/_dist9:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/_dist9:/rpmbuild/RPMS/noarch \
+		-v ${PWD}/_cache_dnf:/var/cache/dnf \
+		ghcr.io/lest/centos-rpm-builder:stream9 \
+		build-spec SOURCES/${PACKAGE}.spec
+	# Test the install
+	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9      
+	[ -d ${PWD}/_cache_dnf ] || mkdir ${PWD}/_cache_dnf
+	docker run --privileged ${DOCKER_FLAGS} \
+		-v ${PWD}/_dist9:/var/tmp/ \
+		-v ${PWD}/_cache_dnf:/var/cache/dnf \
+		ghcr.io/lest/centos-rpm-builder:stream9 \
+		/bin/bash -c '/usr/bin/dnf install --verbose -y /var/tmp/${PACKAGE}*.rpm'
 
 $(addprefix build8-,$(MANUAL)):
 	$(eval PACKAGE=$(subst build8-,,$@))
@@ -112,8 +133,41 @@ $(addprefix build7-,$(MANUAL)):
 		/bin/bash -c '/usr/bin/yum install --verbose -y /var/tmp/${PACKAGE}*.rpm'
 
 
+auto9: $(addprefix build9-,$(AUTO_GENERATED))
 auto8: $(addprefix build8-,$(AUTO_GENERATED))
 auto7: $(addprefix build7-,$(AUTO_GENERATED))
+
+$(addprefix build9-,$(AUTO_GENERATED)):
+	$(eval PACKAGE=$(subst build9-,,$@))
+
+	python3 ./generate.py --templates ${PACKAGE}
+	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9      
+	[ -d ${PWD}/_cache_dnf ] || mkdir ${PWD}/_cache_dnf
+	docker run ${DOCKER_FLAGS} \
+		-v ${PWD}/${PACKAGE}:/rpmbuild/SOURCES \
+		-v ${PWD}/_dist9:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/_dist9:/rpmbuild/RPMS/noarch \
+		-v ${PWD}/_cache_dnf:/var/cache/dnf \
+		ghcr.io/lest/centos-rpm-builder:stream9 \
+		build-spec SOURCES/autogen_${PACKAGE}.spec
+	# Test the install
+	[ -d ${PWD}/_dist9 ] || mkdir ${PWD}/_dist9      
+	[ -d ${PWD}/_cache_dnf ] || mkdir ${PWD}/_cache_dnf
+	docker run --privileged ${DOCKER_FLAGS} \
+		-v ${PWD}/_dist9:/var/tmp/ \
+		-v ${PWD}/_cache_dnf:/var/cache/dnf \
+		ghcr.io/lest/centos-rpm-builder:stream9 \
+		/bin/bash -c '/usr/bin/dnf install --verbose -y /var/tmp/${PACKAGE}*.rpm'
+
+sign9:
+	docker run --rm \
+		-v ${PWD}/_dist9:/rpmbuild/RPMS/x86_64 \
+		-v ${PWD}/bin:/rpmbuild/bin \
+		-v ${PWD}/RPM-GPG-KEY-prometheus-rpm:/rpmbuild/RPM-GPG-KEY-prometheus-rpm \
+		-v ${PWD}/secret.asc:/rpmbuild/secret.asc \
+		-v ${PWD}/.passphrase:/rpmbuild/.passphrase \
+		ghcr.io/lest/centos-rpm-builder:stream9 \
+		bin/sign
 
 $(addprefix build8-,$(AUTO_GENERATED)):
 	$(eval PACKAGE=$(subst build8-,,$@))
@@ -182,6 +236,7 @@ sign7:
 $(foreach \
 	PACKAGE,$(MANUAL),$(eval \
 		${PACKAGE}: \
+			$(addprefix build9-,${PACKAGE}) \
 			$(addprefix build8-,${PACKAGE}) \
 			$(addprefix build7-,${PACKAGE}) \
 	) \
@@ -190,12 +245,16 @@ $(foreach \
 $(foreach \
 	PACKAGE,$(AUTO_GENERATED),$(eval \
 		${PACKAGE}: \
+			$(addprefix build9-,${PACKAGE}) \
 			$(addprefix build8-,${PACKAGE}) \
 			$(addprefix build7-,${PACKAGE}) \
 	) \
 )
 
-sign: sign8 sign7
+sign: sign9 sign8 sign7
+
+publish9: sign9
+	package_cloud push --skip-errors prometheus-rpm/release/el/9 _dist9/*.rpm
 
 publish8: sign8
 	package_cloud push --skip-errors prometheus-rpm/release/el/8 _dist8/*.rpm
@@ -203,7 +262,7 @@ publish8: sign8
 publish7: sign7
 	package_cloud push --skip-errors prometheus-rpm/release/el/7 _dist7/*.rpm
 
-publish: publish8 publish7
+publish: publish9 publish8 publish7
 
 clean:
 	rm -rf _cache_dnf _cache_yum _dist*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/lest/prometheus-rpm/actions/workflows/build.yml/badge.svg) ![Lint Status](https://github.com/lest/prometheus-rpm/actions/workflows/linter.yml/badge.svg) ![Update Status](https://github.com/lest/prometheus-rpm/actions/workflows/check_new_versions.yml/badge.svg)
 
 The repository contains the files needed to build [Prometheus][1] RPM packages
-for CentOS 7 & 8.
+for CentOS 7 & 8 and CentOS Stream 9.
 
 ## Installing
 The packages are available in [the packagecloud repository][2] and can be used


### PR DESCRIPTION
Requires https://github.com/lest/centos-rpm-builder-docker/pull/5