### PR TITLE
Add dellhw_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ sql_exporter \
 nats_exporter \
 prometheus_msteams \
 cadvisor \
-squid_exporter
+squid_exporter \
+dellhw_exporter
 
 .PHONY: $(MANUAL) $(AUTO_GENERATED)
 

--- a/templating.yaml
+++ b/templating.yaml
@@ -915,3 +915,16 @@ packages:
       dynamic:
         <<: *default_dynamic_context
         tarball: '{{URL}}/releases/download/v%{version}/{{package}}'
+  dellhw_exporter:
+    build_steps:
+      <<: *default_build_steps
+    context:
+      <<: *default_context
+      static:
+        <<: *default_static_context
+        version: 1.12.1
+        license: ASL 2.0
+        URL: https://github.com/galexrt/dellhw_exporter
+        summary: Dell Hardware OMSA exporter
+        description: |
+          Prometheus exporter for Dell Hardware components using OMSA.


### PR DESCRIPTION
Add dellhw_exporter from https://github.com/galexrt/dellhw_exporter for Dell/EMC machines with running OMSA.