### PR TITLE
Update Thanos to version 0.29.0

### DIFF
--- a/thanos/thanos.spec
+++ b/thanos/thanos.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:	 thanos
-Version: 0.28.1
+Version: 0.29.0
 Release: 1%{?dist}
 Summary: Highly available Prometheus setup with long term storage capabilities.
 License: ASL 2.0


### PR DESCRIPTION
Bumping Thanos to version 0.29.0

Release notes: https://github.com/thanos-io/thanos/releases/tag/v0.29.0