### PR TITLE
Add Exim4 exporter from https://github.com/gvengel/exim_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ nats_exporter \
 prometheus_msteams \
 cadvisor \
 squid_exporter \
-dellhw_exporter
+dellhw_exporter \
+exim_exporter
 
 .PHONY: $(MANUAL) $(AUTO_GENERATED)
 

--- a/templating.yaml
+++ b/templating.yaml
@@ -928,3 +928,22 @@ packages:
         summary: Dell Hardware OMSA exporter
         description: |
           Prometheus exporter for Dell Hardware components using OMSA.
+  exim_exporter:
+    build_steps:
+      <<: *default_build_steps
+    context:
+      <<: *default_context
+      static:
+        <<: *default_static_context
+        version: 1.4.1
+        license: MIT
+        URL: https://github.com/gvengel/exim_exporter
+        user: exim
+        package: exim_exporter
+        tarball_has_subdirectory: false
+        summary: Prometheus exporter for the exim4 mail server.
+        description: |
+          Prometheus exporter for the exim4 mail server.
+      dynamic:
+        <<: *default_dynamic_context
+        tarball: '{{URL}}/releases/download/v%{version}/{{package}}'


### PR DESCRIPTION
This MR adds Exim4 exporter from https://github.com/gvengel/exim_exporter. To be able to access Exim logs it has to be run from `exim` user.