### PR TITLE
Fix YAML lint issues

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -15,14 +15,14 @@ anchors:
       release: 1
       service_opts: []
       environment: {}
-      #additional_sources:
-      #  - path: example.yml
-      #    from_tarball: false # take file from tarball or repository
-      #    dest: '%{_sysconfdir}/prometheus/example.yml'
-      #    mode: 644           # optional
-      #    user: root          # optional
-      #    group: root         # optional
-      #    config: true        # specify not to override config files
+      # additional_sources:
+      #   - path: example.yml
+      #     from_tarball: false # take file from tarball or repository
+      #     dest: '%{_sysconfdir}/prometheus/example.yml'
+      #     mode: 644           # optional
+      #     user: root          # optional
+      #     group: root         # optional
+      #     config: true        # specify not to override config files
       prep_cmds: []
       build_cmds:
         - /bin/true
@@ -31,7 +31,7 @@ anchors:
       post_cmds: []
       preun_cmds: []
       postun_cmds: []
-      #open_file_limit: 4096   # optionally specify open file limit
+      # open_file_limit: 4096   # optionally specify open file limit
     dynamic: &default_dynamic_context
       tarball: '{{URL}}/releases/download/v%{version}/{{package}}.tar.gz'
       sources:
@@ -83,8 +83,7 @@ packages:
         version: 1.5.0
         license: ASL 2.0
         URL: https://github.com/prometheus/node_exporter
-        summary: Prometheus exporter for machine metrics, written in Go with pluggable
-          metric collectors.
+        summary: Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
         description: |
           Prometheus exporter for hardware and OS metrics exposed by *NIX kernels,
           written in Go with pluggable metric collectors.
@@ -240,8 +239,7 @@ packages:
         version: 1.50.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
-        description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x,
-          4.x, 5.x and 6.x
+        description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x
         package: '%{name}-v%{version}.linux-amd64'
         URL: https://github.com/oliver006/redis_exporter
       dynamic:
@@ -258,10 +256,8 @@ packages:
         URL: https://github.com/prometheus/haproxy_exporter
         service_opts:
           - --haproxy.scrape-uri=unix:/var/lib/haproxy/stats
-        summary: This is a simple server that scrapes HAProxy stats and exports them
-          via HTTP for Prometheus consumption.
-        description: This is a simple server that scrapes HAProxy stats and exports
-          them via HTTP for Prometheus consumption.
+        summary: This is a simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption.
+        description: This is a simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption.
   kafka_exporter:
     build_steps:
       <<: *default_build_steps
@@ -414,10 +410,8 @@ packages:
         license: ASL 2.0
         URL: https://github.com/percona/mongodb_exporter
         package: '%{name}-%{version}.linux-amd64'
-        summary: A Prometheus exporter for MongoDB including sharding, replication
-          and storage engines
-        description: A Prometheus exporter for MongoDB including sharding, replication
-          and storage engines
+        summary: A Prometheus exporter for MongoDB including sharding, replication and storage engines
+        description: A Prometheus exporter for MongoDB including sharding, replication and storage engines
   graphite_exporter:
     build_steps:
       <<: *default_build_steps
@@ -428,8 +422,7 @@ packages:
         version: 0.13.3
         license: ASL 2.0
         URL: https://github.com/prometheus/graphite_exporter
-        summary: Server that accepts metrics via the Graphite protocol and exports
-          them as Prometheus metrics.
+        summary: Server that accepts metrics via the Graphite protocol and exports them as Prometheus metrics.
         description: |
           An exporter for metrics exported in the Graphite plaintext protocol. It
           accepts data over both TCP and UDP, and transforms and exposes them for
@@ -801,8 +794,7 @@ packages:
         fix_name: php-fpm_exporter
         service_opts:
           - server
-        summary: A prometheus exporter for PHP-FPM. The exporter connects directly
-          to PHP-FPM and exports the metrics via HTTP
+        summary: A prometheus exporter for PHP-FPM. The exporter connects directly to PHP-FPM and exports the metrics via HTTP
         description: |
           A prometheus exporter for PHP-FPM
   ipmi_exporter:

--- a/update_templating_versions.py
+++ b/update_templating_versions.py
@@ -108,6 +108,7 @@ def updateGHTemplate(
     formatted_template = io.BytesIO()
     yaml.explicit_start = True
     yaml.indent(sequence=4, offset=2)
+    yaml.width = 500
     yaml.dump(template, formatted_template)
 
     # get existing file checksum:


### PR DESCRIPTION
Set large `yaml.width` value in `update_templating_versions.py` to avoid outputting YAML with trailing whitespace, such as

```yaml
path:
  https://example.com/
```

Also add starting whitespace in `templating.yaml` comments, and unwrap long lines to match the output of
`update_templating_versions.py`.