### PR TITLE
fix pipeline lint and mongodb-exporter version

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -410,7 +410,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 2.37.0
+        version: 0.39.0
         license: ASL 2.0
         URL: https://github.com/percona/mongodb_exporter
         package: '%{name}-%{version}.linux-amd64'

--- a/templating.yaml
+++ b/templating.yaml
@@ -15,14 +15,14 @@ anchors:
       release: 1
       service_opts: []
       environment: {}
-      #additional_sources:
-      #  - path: example.yml
-      #    from_tarball: false # take file from tarball or repository
-      #    dest: '%{_sysconfdir}/prometheus/example.yml'
-      #    mode: 644           # optional
-      #    user: root          # optional
-      #    group: root         # optional
-      #    config: true        # specify not to override config files
+      # additional_sources:
+      #   - path: example.yml
+      #     from_tarball: false # take file from tarball or repository
+      #     dest: '%{_sysconfdir}/prometheus/example.yml'
+      #     mode: 644           # optional
+      #     user: root          # optional
+      #     group: root         # optional
+      #     config: true        # specify not to override config files
       prep_cmds: []
       build_cmds:
         - /bin/true
@@ -31,7 +31,7 @@ anchors:
       post_cmds: []
       preun_cmds: []
       postun_cmds: []
-      #open_file_limit: 4096   # optionally specify open file limit
+      # open_file_limit: 4096   # optionally specify open file limit
     dynamic: &default_dynamic_context
       tarball: '{{URL}}/releases/download/v%{version}/{{package}}.tar.gz'
       sources:


### PR DESCRIPTION
1. Lint fixes are taken from  #804 
2. Version 2.xx tags in percona/mongodb_exporter were created due to a technical error and now are removed; the versions are dropped back to 0.xx, see:
https://github.com/percona/mongodb_exporter/issues/594
https://github.com/percona/mongodb_exporter/issues/613