### PR TITLE
postgres_exporter got updated to 0.15.0, closing critical issue with exhausting of the server pool connections.

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -185,7 +185,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.14.0
+        version: 0.15.0
         license: ASL 2.0
         URL: https://github.com/prometheus-community/postgres_exporter
         user: postgres


### PR DESCRIPTION
[ENHANCEMENT] Add 1kB and 2kB units https://github.com/prometheus-community/postgres_exporter/pull/915
    [BUGFIX] Add error log when probe collector creation fails https://github.com/prometheus-community/postgres_exporter/pull/918
    [BUGFIX] Fix test build failures on 32-bit arch https://github.com/prometheus-community/postgres_exporter/pull/919
    [BUGFIX] Adjust collector to use separate connection per scrape https://github.com/prometheus-community/postgres_exporter/pull/936

That last one created a lot of issues for some deployments.
