### PR TITLE
Change systemd_postun to systemd_postun_restart

### DIFF
--- a/templates/spec.tpl
+++ b/templates/spec.tpl
@@ -160,7 +160,7 @@ if [ "$1" -ge "1" ] ; then
     service %{name} condrestart >/dev/null 2>&1 || :
 fi
 %else
-%systemd_postun %{name}.service
+%systemd_postun_restart %{name}.service
 %endif
 {%- for postun_cmd in postun_cmds %}
 {{ postun_cmd }}


### PR DESCRIPTION
Change the spec template to call systemd_postun_restart instead of %systemd_postun %{name}.service.

Currently the behavior is that a "yum update" updates the software but never restarts the daemons if they are running,
leaving the old binary to serve out data.
The _restart method changes this to restart the service if it's started.
 