### PR TITLE
ci: remove el7 as it is EOL and causes builds to fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
         version:
           - 9
           - 8
-          - 7
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -56,7 +55,6 @@ jobs:
         version:
           - 9
           - 8
-          - 7
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Currently all builds fail on el7 packaging as the upstream el7 mirrors have been removed following the EOL of el7.